### PR TITLE
Fix ForceEpochChange + pubKeysBitMap for integration tests

### DIFF
--- a/cmd/sovereignnode/chainSimulator/sovereignChainSimulator_test.go
+++ b/cmd/sovereignnode/chainSimulator/sovereignChainSimulator_test.go
@@ -123,7 +123,7 @@ func TestSovereignSimulator_TriggerChangeOfEpoch(t *testing.T) {
 				Value:    20,
 			},
 			ApiInterface:     api.NewNoApiInterface(),
-			MinNodesPerShard: 1,
+			MinNodesPerShard: 100,
 		},
 	})
 	require.Nil(t, err)

--- a/cmd/sovereignnode/go.mod
+++ b/cmd/sovereignnode/go.mod
@@ -1,6 +1,6 @@
 module github.com/multiversx/mx-chain-go/sovereignnode
 
-replace github.com/multiversx/mx-chain-go => ../../../mx-chain-go
+replace github.com/multiversx/mx-chain-go => ../../../mx-chain-sovereign-go
 
 go 1.20
 

--- a/epochStart/metachain/sovereignTrigger.go
+++ b/epochStart/metachain/sovereignTrigger.go
@@ -7,6 +7,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/core/check"
 	"github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-core-go/data/block"
+
 	"github.com/multiversx/mx-chain-go/dataRetriever"
 	"github.com/multiversx/mx-chain-go/epochStart"
 	"github.com/multiversx/mx-chain-go/process"
@@ -184,6 +185,10 @@ func (st *sovereignTrigger) checkIfTriggerCanBeActivated(hdr data.HeaderHandler)
 
 	st.epochStartNotifier.NotifyAllPrepare(hdr, blockBody)
 	return true
+}
+
+// ForceEpochStart does nothing
+func (st *sovereignTrigger) ForceEpochStart(_ uint64) {
 }
 
 // IsInterfaceNil checks if the underlying pointer is nil

--- a/node/chainSimulator/chainSimulator_test.go
+++ b/node/chainSimulator/chainSimulator_test.go
@@ -131,7 +131,7 @@ func TestSimulator_TriggerChangeOfEpoch(t *testing.T) {
 	roundDurationInMillis := uint64(6000)
 	roundsPerEpoch := core.OptionalUint64{
 		HasValue: true,
-		Value:    15000,
+		Value:    150,
 	}
 	chainSimulator, err := NewChainSimulator(ArgsChainSimulator{
 		BypassTxSignatureCheck: true,

--- a/node/chainSimulator/process/processor.go
+++ b/node/chainSimulator/process/processor.go
@@ -72,10 +72,8 @@ func (creator *blocksCreator) CreateNewBlock() error {
 		return err
 	}
 
-	cnsGroupSize := creator.nodeHandler.GetProcessComponents().NodesCoordinator().ConsensusGroupSize(epoch)
-	pkMap := make([]byte, cnsGroupSize/8+1)
-	pkMap[0] = 1
-	err = newHeader.SetPubKeysBitmap(pkMap)
+	pubKeysBitMap := creator.createPubKeysBitMap(epoch)
+	err = newHeader.SetPubKeysBitmap(pubKeysBitMap)
 	if err != nil {
 		return err
 	}
@@ -165,6 +163,14 @@ func (creator *blocksCreator) getPreviousHeaderData() (nonce, round uint64, prev
 	nonce = creator.nodeHandler.GetChainHandler().GetGenesisHeader().GetNonce()
 
 	return
+}
+
+func (creator *blocksCreator) createPubKeysBitMap(epoch uint32) []byte {
+	cnsGroupSize := creator.nodeHandler.GetProcessComponents().NodesCoordinator().ConsensusGroupSize(epoch)
+	pkMap := make([]byte, cnsGroupSize/8+1)
+	pkMap[0] = 1
+
+	return pkMap
 }
 
 func (creator *blocksCreator) setHeaderSignatures(header data.HeaderHandler, blsKeyBytes []byte) error {

--- a/node/chainSimulator/process/processor.go
+++ b/node/chainSimulator/process/processor.go
@@ -72,7 +72,10 @@ func (creator *blocksCreator) CreateNewBlock() error {
 		return err
 	}
 
-	err = newHeader.SetPubKeysBitmap([]byte{1})
+	cnsGroupSize := creator.nodeHandler.GetProcessComponents().NodesCoordinator().ConsensusGroupSize(epoch)
+	pkMap := make([]byte, cnsGroupSize/8+1)
+	pkMap[0] = 1
+	err = newHeader.SetPubKeysBitmap(pkMap)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Reasoning behind the pull request
- `TestSovereignSimulator_TriggerChangeOfEpoch` did not work with `MinNodesPerShard` != 1
  
## Proposed changes
- Deleted code for `ForceEpochChange` -> this is disabled on shard processing and it should also not exist on sovereign. This func was also only being used for testing purposes
- Fixed `pubKeysBitMap` in chain simulator when creating new header

## Testing procedure
- 
- 
- 

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
