### PR TITLE
Fix NTP query time and offset response allowed round percentage

### DIFF
--- a/integrationTests/testConsensusNode.go
+++ b/integrationTests/testConsensusNode.go
@@ -16,7 +16,6 @@ import (
 	crypto "github.com/multiversx/mx-chain-crypto-go"
 	mclMultiSig "github.com/multiversx/mx-chain-crypto-go/signing/mcl/multisig"
 	"github.com/multiversx/mx-chain-crypto-go/signing/multisig"
-	"github.com/multiversx/mx-chain-go/testscommon/components"
 
 	"github.com/multiversx/mx-chain-go/config"
 	"github.com/multiversx/mx-chain-go/consensus"
@@ -42,6 +41,7 @@ import (
 	"github.com/multiversx/mx-chain-go/storage/cache"
 	"github.com/multiversx/mx-chain-go/storage/storageunit"
 	"github.com/multiversx/mx-chain-go/testscommon"
+	"github.com/multiversx/mx-chain-go/testscommon/components"
 	"github.com/multiversx/mx-chain-go/testscommon/cryptoMocks"
 	dataRetrieverMock "github.com/multiversx/mx-chain-go/testscommon/dataRetriever"
 	"github.com/multiversx/mx-chain-go/testscommon/enableEpochsHandlerMock"
@@ -195,13 +195,14 @@ func (tcn *TestConsensusNode) initNode(args ArgsTestConsensusNode) {
 	tcn.initBlockChain(testHasher)
 	tcn.initBlockProcessor()
 
-	syncer := ntp.NewSyncTime(ntp.NewNTPGoogleConfig(), nil)
+	roundTime := time.Millisecond * time.Duration(args.RoundTime)
+	syncer := ntp.NewSyncTime(ntp.NewNTPGoogleConfig(), nil, roundTime)
 	syncer.StartSyncingTime()
 
 	roundHandler, _ := round.NewRound(
 		time.Unix(args.StartTime, 0),
 		syncer.CurrentTime(),
-		time.Millisecond*time.Duration(args.RoundTime),
+		roundTime,
 		syncer,
 		0)
 

--- a/ntp/export_test.go
+++ b/ntp/export_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 // OutOfBoundsDuration -
-const OutOfBoundsDuration = outOfBoundsDuration
+const OutOfBoundsDuration = outOfBoundsRoundDurationPercentage
 
 // Query -
 func (s *syncTime) Query() func(options NTPOptions, hostIndex int) (*ntp.Response, error) {

--- a/ntp/syncTime.go
+++ b/ntp/syncTime.go
@@ -234,7 +234,7 @@ func (s *syncTime) sync() {
 
 	s.setClockOffset(clockOffsetHarmonicMean)
 
-	log.Error("sync.setClockOffset done",
+	log.Debug("sync.setClockOffset done",
 		"num clock offsets", len(clockOffsets),
 		"num clock offsets without edges", len(clockOffsetsWithoutEdges),
 		"clock offset harmonic mean", clockOffsetHarmonicMean)

--- a/ntp/syncTime.go
+++ b/ntp/syncTime.go
@@ -186,7 +186,7 @@ func (s *syncTime) sync() {
 			}
 
 			if duration.Milliseconds() > maxAllowedNTPQueryResponseTimeMS {
-				log.Debug("sync.query exceeds maximum allowed response time",
+				log.Trace("sync.query exceeds maximum allowed response time",
 					"host", s.ntpOptions.Hosts[hostIndex],
 					"port", s.ntpOptions.Port,
 					"duration", duration,

--- a/ntp/syncTime.go
+++ b/ntp/syncTime.go
@@ -13,8 +13,9 @@ import (
 	"github.com/beevik/ntp"
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/core/closing"
-	"github.com/multiversx/mx-chain-go/config"
 	"github.com/multiversx/mx-chain-logger-go"
+
+	"github.com/multiversx/mx-chain-go/config"
 )
 
 var _ SyncTimer = (*syncTime)(nil)
@@ -39,7 +40,13 @@ const maxOffsetPercent = 0.2
 // minTimeout represents the minimum time in milliseconds to wait for a response from a host after a NTP request
 const minTimeout = 100
 
-const outOfBoundsDuration = time.Second
+// outOfBoundsRoundDurationPercentage specifies the percentage of the round duration
+// that determines the allowable clock offset beyond the defined limits.
+const outOfBoundsRoundDurationPercentage = 20 // 20% * roundDuration
+
+// maxAllowedNTPQueryResponseTimeMS specifies the maximum duration (in milliseconds)
+// allowed for an NTP query. If a query takes longer than this limit, its response will be disregarded.
+const maxAllowedNTPQueryResponseTimeMS = 200
 
 // NTPOptions defines configuration options for a NTP query
 type NTPOptions struct {
@@ -95,12 +102,13 @@ func queryNTP(options NTPOptions, hostIndex int) (*ntp.Response, error) {
 
 // syncTime defines an object for time synchronization
 type syncTime struct {
-	mut         sync.RWMutex
-	clockOffset time.Duration
-	syncPeriod  time.Duration
-	ntpOptions  NTPOptions
-	query       func(options NTPOptions, hostIndex int) (*ntp.Response, error)
-	cancelFunc  func()
+	mut           sync.RWMutex
+	clockOffset   time.Duration
+	syncPeriod    time.Duration
+	ntpOptions    NTPOptions
+	query         func(options NTPOptions, hostIndex int) (*ntp.Response, error)
+	cancelFunc    func()
+	roundDuration time.Duration
 }
 
 // NewSyncTime creates a syncTime object. The customQueryFunc argument allows the caller to set a different NTP-querying
@@ -108,6 +116,7 @@ type syncTime struct {
 func NewSyncTime(
 	ntpConfig config.NTPConfig,
 	customQueryFunc func(options NTPOptions, hostIndex int) (*ntp.Response, error),
+	roundDuration time.Duration,
 ) *syncTime {
 	queryFunc := customQueryFunc
 	if queryFunc == nil {
@@ -115,10 +124,11 @@ func NewSyncTime(
 	}
 
 	s := syncTime{
-		clockOffset: 0,
-		syncPeriod:  time.Duration(ntpConfig.SyncPeriodSeconds) * time.Second,
-		query:       queryFunc,
-		ntpOptions:  NewNTPOptions(ntpConfig),
+		clockOffset:   0,
+		syncPeriod:    time.Duration(ntpConfig.SyncPeriodSeconds) * time.Second,
+		query:         queryFunc,
+		ntpOptions:    NewNTPOptions(ntpConfig),
+		roundDuration: roundDuration,
 	}
 
 	return &s
@@ -163,13 +173,24 @@ func (s *syncTime) sync() {
 	clockOffsets := make([]time.Duration, 0)
 	for hostIndex := 0; hostIndex < len(s.ntpOptions.Hosts); hostIndex++ {
 		for requests := 0; requests < numRequestsFromHost; requests++ {
+			startTime := time.Now()
 			response, err := s.query(s.ntpOptions, hostIndex)
+			duration := time.Since(startTime)
 			if err != nil {
 				log.Debug("sync.query",
 					"host", s.ntpOptions.Hosts[hostIndex],
 					"port", s.ntpOptions.Port,
 					"error", err.Error())
 
+				continue
+			}
+
+			if duration.Milliseconds() > maxAllowedNTPQueryResponseTimeMS {
+				log.Debug("sync.query exceeds maximum allowed response time",
+					"host", s.ntpOptions.Hosts[hostIndex],
+					"port", s.ntpOptions.Port,
+					"duration", duration,
+					"maxAllowedNTPQueryResponseTimeMS", maxAllowedNTPQueryResponseTimeMS)
 				continue
 			}
 
@@ -197,17 +218,23 @@ func (s *syncTime) sync() {
 
 	clockOffsetsWithoutEdges := s.getClockOffsetsWithoutEdges(clockOffsets)
 	clockOffsetHarmonicMean := s.getHarmonicMean(clockOffsetsWithoutEdges)
-	isOutOfBounds := core.AbsDuration(clockOffsetHarmonicMean)-outOfBoundsDuration > 0
+
+	thresholdOutOfBonds := s.roundDuration * time.Duration(outOfBoundsRoundDurationPercentage) / time.Duration(100)
+	isOutOfBounds := core.AbsDuration(clockOffsetHarmonicMean) > thresholdOutOfBonds
 	if isOutOfBounds {
 		log.Error("syncTime.sync: clock offset is out of expected bounds",
-			"clock offset harmonic mean", clockOffsetHarmonicMean)
+			"clock offset harmonic mean", clockOffsetHarmonicMean,
+			"thresholdOutOfBonds", thresholdOutOfBonds,
+			"outOfBoundsRoundDurationPercentage", outOfBoundsRoundDurationPercentage,
+			"roundDuration", s.roundDuration,
+		)
 
 		return
 	}
 
 	s.setClockOffset(clockOffsetHarmonicMean)
 
-	log.Debug("sync.setClockOffset done",
+	log.Error("sync.setClockOffset done",
 		"num clock offsets", len(clockOffsets),
 		"num clock offsets without edges", len(clockOffsetsWithoutEdges),
 		"clock offset harmonic mean", clockOffsetHarmonicMean)


### PR DESCRIPTION
## Reasoning behind the pull request
- Fix query NTP max allowed response time by using a 200 ms threshold
- Consider a clock offset setting is out of bounds if it exceeds 20% * roundDuration
- This fix would be also very useful on mainchain when round time will be lowered
- On local machine, seems like the avg. ntp query response time is 35 ms
  
## Proposed changes
- 
- 
- 

## Testing procedure
- 
- 
- 

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
