### PR TITLE
Fix genesis accounts indexing & vm-common go mod

### DIFF
--- a/factory/processing/processComponents.go
+++ b/factory/processing/processComponents.go
@@ -69,7 +69,6 @@ import (
 	"github.com/multiversx/mx-chain-go/sharding/networksharding"
 	"github.com/multiversx/mx-chain-go/sharding/nodesCoordinator"
 	"github.com/multiversx/mx-chain-go/state"
-	"github.com/multiversx/mx-chain-go/state/accounts"
 	"github.com/multiversx/mx-chain-go/state/parsers"
 	"github.com/multiversx/mx-chain-go/storage"
 	"github.com/multiversx/mx-chain-go/storage/cache"
@@ -925,13 +924,13 @@ func (pcf *processComponentsFactory) indexAndReturnGenesisAccounts() (map[string
 
 	genesisAccounts := make(map[string]*alteredAccount.AlteredAccount, 0)
 	for leaf := range leavesChannels.LeavesChan {
-		userAccount, errUnmarshal := pcf.unmarshalUserAccount(leaf.Value())
+		userAccount, errUnmarshal := pcf.getUserAccount(leaf.Key(), leaf.Value())
 		if errUnmarshal != nil {
 			log.Debug("cannot unmarshal genesis user account. it may be a code leaf", "error", errUnmarshal)
 			continue
 		}
 
-		encodedAddress, errEncode := pcf.coreData.AddressPubKeyConverter().Encode(userAccount.GetAddress())
+		encodedAddress, errEncode := pcf.coreData.AddressPubKeyConverter().Encode(userAccount.AddressBytes())
 		if errEncode != nil {
 			return map[string]*alteredAccount.AlteredAccount{}, errEncode
 		}
@@ -961,11 +960,18 @@ func (pcf *processComponentsFactory) indexAndReturnGenesisAccounts() (map[string
 	return genesisAccounts, nil
 }
 
-func (pcf *processComponentsFactory) unmarshalUserAccount(userAccountsBytes []byte) (*accounts.UserAccountData, error) {
-	userAccount := &accounts.UserAccountData{}
-	err := pcf.coreData.InternalMarshalizer().Unmarshal(userAccount, userAccountsBytes)
+func (pcf *processComponentsFactory) getUserAccount(
+	address []byte,
+	userAccountsBytes []byte,
+) (state.UserAccountHandler, error) {
+	account, err := pcf.state.AccountsAdapter().GetAccountFromBytes(address, userAccountsBytes)
 	if err != nil {
 		return nil, err
+	}
+
+	userAccount, ok := account.(state.UserAccountHandler)
+	if !ok {
+		return nil, process.ErrWrongTypeAssertion
 	}
 
 	return userAccount, nil

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/multiversx/mx-chain-go
 replace (
 	github.com/multiversx/mx-chain-core-go => github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20250408132734-79aa4c1dd15e
 	github.com/multiversx/mx-chain-es-indexer-go => github.com/multiversx/mx-chain-es-indexer-sovereign-go v1.7.17-0.20250310091256-70440107b782
-	github.com/multiversx/mx-chain-vm-common-go => github.com/multiversx/mx-chain-vm-common-sovereign-go v1.5.17-0.20250310160624-2027f24f8de5
+	github.com/multiversx/mx-chain-vm-common-go => github.com/multiversx/mx-chain-vm-common-sovereign-go v1.5.17-0.20250612113809-4ced1f92c22e
 )
 
 go 1.20

--- a/go.sum
+++ b/go.sum
@@ -407,8 +407,8 @@ github.com/multiversx/mx-chain-sovereign-notifier-go v0.0.0-20250401112546-700ac
 github.com/multiversx/mx-chain-sovereign-notifier-go v0.0.0-20250401112546-700ac474fa5c/go.mod h1:lC11Gf27XxA9kHgmyYhls/Mw0fRbuR5uDPpri2MBeL4=
 github.com/multiversx/mx-chain-storage-go v1.0.19 h1:2R35MoSXcuNJOFmV5xEhcXqiEGZw6AYGy9R8J9KH66Q=
 github.com/multiversx/mx-chain-storage-go v1.0.19/go.mod h1:Pb/BuVmiFqO66DSZO16KFkSUeom94x3e3Q9IloBvkYI=
-github.com/multiversx/mx-chain-vm-common-sovereign-go v1.5.17-0.20250310160624-2027f24f8de5 h1:tdnMVSR+LJQ05E/HolsQy7VYPcgJ0LzF9mrPL2W4pKI=
-github.com/multiversx/mx-chain-vm-common-sovereign-go v1.5.17-0.20250310160624-2027f24f8de5/go.mod h1:C7KVj6/+TAhxDjgY7oAMO5wSj7WbBYIJ5TCMzmxk2w0=
+github.com/multiversx/mx-chain-vm-common-sovereign-go v1.5.17-0.20250612113809-4ced1f92c22e h1:k8REFw9tKu2j9pIYT/UgOKN0w5cLBji1o/xM2Mp8xag=
+github.com/multiversx/mx-chain-vm-common-sovereign-go v1.5.17-0.20250612113809-4ced1f92c22e/go.mod h1:572hesYTHS5DdRzASZSqpzfABG437EpSc/RLqFFqkCw=
 github.com/multiversx/mx-chain-vm-go v1.5.37 h1:Iy3KCvM+DOq1f9UPA7uYK/rI3ZbBOXc2CVNO2/vm5zw=
 github.com/multiversx/mx-chain-vm-go v1.5.37/go.mod h1:nzLrWeXvfxCIiwj5uNBZq3d7stkXyeY+Fktfr4tTaiY=
 github.com/multiversx/mx-chain-vm-v1_2-go v1.2.68 h1:L3GoAVFtLLzr9ya0rVv1YdTUzS3MyM7kQNBSAjCNO2g=


### PR DESCRIPTION
## Reasoning behind the pull request
- 
- 
- 
  
## Proposed changes
- Index genesis accounts balance fix
- go.mod vm-common from [fix esdt wipe](https://github.com/multiversx/mx-chain-vm-common-sovereign-go/pull/6)
- 

## Testing procedure
- 
- 
- 

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
