### PR TITLE
Validator main chain id as []byte of any size

### DIFF
--- a/cmd/sovereignnode/chainSimulator/tests/epochChange/epochChange_test.go
+++ b/cmd/sovereignnode/chainSimulator/tests/epochChange/epochChange_test.go
@@ -143,7 +143,7 @@ func TestSovereignChainSimulator_EpochChange(t *testing.T) {
 	// all pub key ids from genesis are in ascending order
 	allPubKeyIDs := make([][]byte, 8)
 	for idx := 0; idx < 8; idx++ {
-		allPubKeyIDs[idx] = []byte{0x0, byte(idx)}
+		allPubKeyIDs[idx] = []byte{byte(idx)}
 	}
 
 	for epoch := 41; epoch <= 45; epoch++ {

--- a/genesis/process/sovereignGenesisBlockCreator.go
+++ b/genesis/process/sovereignGenesisBlockCreator.go
@@ -459,8 +459,15 @@ func setGenesisNodeChainID(id int, peerAccountsDB state.AccountsAdapter, key []b
 		return err
 	}
 
-	valAcc.SetMainChainID(big.NewInt(int64(id)).Bytes())
+	valAcc.SetMainChainID(idToBytes(id))
 	return peerAccountsDB.SaveAccount(valAcc)
+}
+
+func idToBytes(id int) []byte {
+	if id == 0 {
+		return []byte{0x00}
+	}
+	return big.NewInt(int64(id)).Bytes()
 }
 
 func getPeerAccount(peerAccountsDB state.AccountsAdapter, key []byte) (state.PeerAccountHandler, error) {

--- a/genesis/process/sovereignGenesisBlockCreator.go
+++ b/genesis/process/sovereignGenesisBlockCreator.go
@@ -459,15 +459,15 @@ func setGenesisNodeChainID(id int, peerAccountsDB state.AccountsAdapter, key []b
 		return err
 	}
 
-	valAcc.SetMainChainID(idToBytes(id))
+	valAcc.SetMainChainID(intToBytes(id))
 	return peerAccountsDB.SaveAccount(valAcc)
 }
 
-func idToBytes(id int) []byte {
-	if id == 0 {
+func intToBytes(n int) []byte {
+	if n == 0 {
 		return []byte{0x00}
 	}
-	return big.NewInt(int64(id)).Bytes()
+	return big.NewInt(int64(n)).Bytes()
 }
 
 func getPeerAccount(peerAccountsDB state.AccountsAdapter, key []byte) (state.PeerAccountHandler, error) {

--- a/genesis/process/sovereignGenesisBlockCreator.go
+++ b/genesis/process/sovereignGenesisBlockCreator.go
@@ -465,7 +465,7 @@ func setGenesisNodeChainID(id int, peerAccountsDB state.AccountsAdapter, key []b
 
 func intToBytes(n int) []byte {
 	if n == 0 {
-		return []byte{0x00}
+		return []byte{0x0}
 	}
 	return big.NewInt(int64(n)).Bytes()
 }

--- a/genesis/process/sovereignGenesisBlockCreator.go
+++ b/genesis/process/sovereignGenesisBlockCreator.go
@@ -1,7 +1,6 @@
 package process
 
 import (
-	"encoding/binary"
 	"encoding/hex"
 	"fmt"
 	"math"
@@ -460,14 +459,8 @@ func setGenesisNodeChainID(id int, peerAccountsDB state.AccountsAdapter, key []b
 		return err
 	}
 
-	valAcc.SetMainChainID(intTo2Bytes(id))
+	valAcc.SetMainChainID(big.NewInt(int64(id)).Bytes())
 	return peerAccountsDB.SaveAccount(valAcc)
-}
-
-func intTo2Bytes(n int) []byte {
-	b := make([]byte, 2)
-	binary.BigEndian.PutUint16(b, uint16(n)) // Convert only the lower 2 bytes
-	return b
 }
 
 func getPeerAccount(peerAccountsDB state.AccountsAdapter, key []byte) (state.PeerAccountHandler, error) {

--- a/genesis/process/sovereignGenesisBlockCreator_test.go
+++ b/genesis/process/sovereignGenesisBlockCreator_test.go
@@ -502,15 +502,15 @@ func TestSovereignGenesisBlockCreator_setSovereignStakedDataAndCheckMainChainID(
 
 	acc1, err := getPeerAccount(args.ValidatorAccounts, initialNode1.PubKeyBytesValue)
 	require.Nil(t, err)
-	require.Equal(t, []byte{0x0, 0x0}, acc1.GetMainChainID())
+	require.Equal(t, []byte{0x0}, acc1.GetMainChainID())
 
 	acc2, err := getPeerAccount(args.ValidatorAccounts, initialNode2.PubKeyBytesValue)
 	require.Nil(t, err)
-	require.Equal(t, []byte{0x0, 0x1}, acc2.GetMainChainID())
+	require.Equal(t, []byte{0x1}, acc2.GetMainChainID())
 
 	acc3, err := getPeerAccount(args.ValidatorAccounts, initialNode3.PubKeyBytesValue)
 	require.Nil(t, err)
-	require.Equal(t, []byte{0x0, 0x2}, acc3.GetMainChainID())
+	require.Equal(t, []byte{0x2}, acc3.GetMainChainID())
 }
 
 func TestSovereignGenesisBlockCreator_InitSystemAccountCalled(t *testing.T) {


### PR DESCRIPTION
## Reasoning behind the pull request
- 2 bytes ID might introduce problems and edge cases
- 
- 
  
## Proposed changes
- Use validator main chain id as []byte of any size, each new validator will get a new ID
- 
- 

## Testing procedure
- 
- 
- 

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
