### PR TITLE
Extra signers in header proofs

### DIFF
--- a/cmd/sovereignnode/config/prefs.toml
+++ b/cmd/sovereignnode/config/prefs.toml
@@ -48,7 +48,7 @@
       { File = "config.toml", Path = "Versions.DefaultVersion", Value = "S1" },
       { File = "config.toml", Path = "Versions.VersionsByEpochs", Value = [{ StartEpoch = 0, Version = "S1" }] },
       { File = "systemSmartContractsConfig.toml", Path = "ESDTSystemSCConfig.BaseIssuingCost", Value = "50000000000000000" },
-      { File = "economics.toml", Path = "FeeSettings.GasLimitSettings", Value = [{EnableEpoch = 0, MaxGasLimitPerBlock = "500000000", MaxGasLimitPerMiniBlock = "500000000", MaxGasLimitPerMetaBlock = "5000000000", MaxGasLimitPerMetaMiniBlock = "5000000000", MaxGasLimitPerTx = "500000000", MinGasLimit = "50000", ExtraGasLimitGuardedTx = "50000"}] },
+      { File = "economics.toml", Path = "FeeSettings.GasLimitSettings", Value = [{EnableEpoch = 0, MaxGasLimitPerBlock = "500000000", MaxGasLimitPerMiniBlock = "500000000", MaxGasLimitPerMetaBlock = "5000000000", MaxGasLimitPerMetaMiniBlock = "5000000000", MaxGasLimitPerTx = "500000000", MinGasLimit = "50000", ExtraGasLimitGuardedTx = "50000", MaxGasHigherFactorAccepted = "2"}] },
    ]
 
 # BlockProcessingCutoff can be used to stop processing blocks at a certain round, nonce or epoch.

--- a/cmd/sovereignnode/sovereignNodeRunner.go
+++ b/cmd/sovereignnode/sovereignNodeRunner.go
@@ -1019,7 +1019,10 @@ func (snr *sovereignNodeRunner) CreateManagedConsensusComponents(
 	return managedConsensusComponents, nil
 }
 
-func createOutGoingTxDataSigners(signingHandler consensus.SigningHandler, enableEpochsHandler common.EnableEpochsHandler) (bls.ExtraSignersHolder, error) {
+func createOutGoingTxDataSigners(
+	signingHandler consensus.SigningHandler,
+	enableEpochsHandler common.EnableEpochsHandler,
+) (bls.ExtraSignersHolder, error) {
 	startRoundExtraSignersHolder := holders.NewSubRoundStartExtraSignersHolder()
 	signRoundExtraSignersHolder := holders.NewSubRoundSignatureExtraSignersHolder()
 	endRoundExtraSignersHolder := holders.NewSubRoundEndExtraSignersHolder()

--- a/cmd/sovereignnode/sovereignNodeRunner.go
+++ b/cmd/sovereignnode/sovereignNodeRunner.go
@@ -978,7 +978,7 @@ func (snr *sovereignNodeRunner) CreateManagedConsensusComponents(
 		return nil, err
 	}
 
-	extraSignersHolder, err := createOutGoingTxDataSigners(cryptoComponents.ConsensusSigningHandler())
+	extraSignersHolder, err := createOutGoingTxDataSigners(cryptoComponents.ConsensusSigningHandler(), coreComponents.EnableEpochsHandler())
 	if err != nil {
 		return nil, err
 	}
@@ -1019,7 +1019,7 @@ func (snr *sovereignNodeRunner) CreateManagedConsensusComponents(
 	return managedConsensusComponents, nil
 }
 
-func createOutGoingTxDataSigners(signingHandler consensus.SigningHandler) (bls.ExtraSignersHolder, error) {
+func createOutGoingTxDataSigners(signingHandler consensus.SigningHandler, enableEpochsHandler common.EnableEpochsHandler) (bls.ExtraSignersHolder, error) {
 	startRoundExtraSignersHolder := holders.NewSubRoundStartExtraSignersHolder()
 	signRoundExtraSignersHolder := holders.NewSubRoundSignatureExtraSignersHolder()
 	endRoundExtraSignersHolder := holders.NewSubRoundEndExtraSignersHolder()
@@ -1046,7 +1046,7 @@ func createOutGoingTxDataSigners(signingHandler consensus.SigningHandler) (bls.E
 			return nil, err
 		}
 
-		endRoundExtraSignerOutGoingTx, err := extraSigners.NewSovereignSubRoundEndExtraSigner(extraSignerHandler, mbType)
+		endRoundExtraSignerOutGoingTx, err := extraSigners.NewSovereignSubRoundEndExtraSigner(extraSignerHandler, mbType, enableEpochsHandler)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/sovereignnode/sovereignNodeRunner.go
+++ b/cmd/sovereignnode/sovereignNodeRunner.go
@@ -1024,9 +1024,7 @@ func createOutGoingTxDataSigners(signingHandler consensus.SigningHandler) (bls.E
 	signRoundExtraSignersHolder := holders.NewSubRoundSignatureExtraSignersHolder()
 	endRoundExtraSignersHolder := holders.NewSubRoundEndExtraSignersHolder()
 
-	// TODO: MX-17039 Restore these once outgoing operations are functional
-	mbTypes := []block.OutGoingMBType{ /*block.OutGoingMbTx, block.OutGoingMbChangeValidatorSet*/ }
-
+	mbTypes := []block.OutGoingMBType{block.OutGoingMbTx, block.OutGoingMbChangeValidatorSet}
 	for _, mbType := range mbTypes {
 		extraSignerHandler := signingHandler.ShallowClone()
 

--- a/consensus/interface.go
+++ b/consensus/interface.go
@@ -253,5 +253,6 @@ type ProofHandler interface {
 	GetHeaderNonce() uint64
 	GetHeaderShardId() uint32
 	GetIsStartOfEpoch() bool
+	GetExtraSignatureHandlers() map[string]data.ExtraSignatureDataHandler
 	IsInterfaceNil() bool
 }

--- a/consensus/interface.go
+++ b/consensus/interface.go
@@ -78,6 +78,7 @@ type SubRoundEndExtraSignatureHandler interface {
 	SetAggregatedSignatureInHeader(header data.HeaderHandler, aggregatedSig []byte) error
 	SetConsensusDataInHeader(header data.HeaderHandler, cnsMsg *Message) error
 	VerifyAggregatedSignatures(bitmap []byte, header data.HeaderHandler) error
+	GetLeaderExtraSig(header data.HeaderHandler) ([]byte, error)
 	Identifier() string
 	IsInterfaceNil() bool
 }

--- a/consensus/spos/bls/interface.go
+++ b/consensus/spos/bls/interface.go
@@ -35,6 +35,7 @@ type SubRoundEndExtraSignersHolder interface {
 	SetAggregatedSignatureInHeader(header data.HeaderHandler, aggregatedSigs map[string][]byte) error
 	VerifyAggregatedSignatures(header data.HeaderHandler, bitmap []byte) error
 	HaveConsensusHeaderWithFullInfo(header data.HeaderHandler, cnsMsg *consensus.Message) error
+	GetLeaderExtraSig(header data.HeaderHandler, id string) ([]byte, error)
 	RegisterExtraSigningHandler(extraSigner consensus.SubRoundEndExtraSignatureHandler) error
 	IsInterfaceNil() bool
 }

--- a/consensus/spos/bls/sovereign/blsSubroundsFactory.go
+++ b/consensus/spos/bls/sovereign/blsSubroundsFactory.go
@@ -203,7 +203,7 @@ func (fct *factory) generateEndRoundSubroundV2() error {
 	// 1. Remove handler for base received proof from cns v2
 	// 2. Add aggregated sig for outgoing ops in proof to be received on sovereign sub round handler
 	// 3. Implement sov sub round handler to received proofs, which should also call base receivedProof handler
-	//fct.worker.AddReceivedProofHandler(sovEndRound.ReceivedProof)
+	fct.worker.AddReceivedProofHandler(sovEndRound.ReceivedProof)
 
 	fct.worker.AddReceivedMessageCall(bls.MtBlockHeaderFinalInfo, sovEndRound.receivedBlockHeaderFinalInfo)
 	fct.consensusCore.Chronology().AddSubround(sovEndRound)

--- a/consensus/spos/bls/sovereign/blsSubroundsFactory.go
+++ b/consensus/spos/bls/sovereign/blsSubroundsFactory.go
@@ -198,14 +198,11 @@ func (fct *factory) generateEndRoundSubroundV2() error {
 	}
 
 	fct.worker.ResetHandlers(bls.MtBlockHeaderFinalInfo)
+	fct.worker.ResetReceivedProofHandler()
 
-	// TODO: MX-17039 Here we need to:
-	// 1. Remove handler for base received proof from cns v2
-	// 2. Add aggregated sig for outgoing ops in proof to be received on sovereign sub round handler
-	// 3. Implement sov sub round handler to received proofs, which should also call base receivedProof handler
 	fct.worker.AddReceivedProofHandler(sovEndRound.ReceivedProof)
-
 	fct.worker.AddReceivedMessageCall(bls.MtBlockHeaderFinalInfo, sovEndRound.receivedBlockHeaderFinalInfo)
+
 	fct.consensusCore.Chronology().AddSubround(sovEndRound)
 
 	return nil

--- a/consensus/spos/bls/sovereign/sovereignSubRoundEnd.go
+++ b/consensus/spos/bls/sovereign/sovereignSubRoundEnd.go
@@ -63,13 +63,20 @@ func (sr *sovereignSubRoundEnd) receivedBlockHeaderFinalInfo(ctx context.Context
 }
 
 func (sr *sovereignSubRoundEnd) ReceivedProof(proof consensus.ProofHandler) {
-	// TODO: MX-17039 add received message in factory for this func
-
 	sr.subroundEndRoundV2.ReceivedProof(proof)
+
+	extraSigsOutGoingOps := make(map[string]*consensus.ExtraSignatureData)
+
+	for id, sigData := range proof.GetExtraSignatureHandlers() {
+		extraSigsOutGoingOps[id] = &consensus.ExtraSignatureData{
+			AggregatedSignatureOutGoingTxData: sigData.GetAggregatedSignature(),
+			LeaderSignatureOutGoingTxData:     sigData.GetLeaderSignature(),
+		}
+	}
 
 	err := sr.updateOutGoingPoolIfNeeded(&consensus.Message{
 		PubKeysBitmap:   proof.GetPubKeysBitmap(),
-		ExtraSignatures: nil, // TODO: MX-17039 integrate this in proofs
+		ExtraSignatures: extraSigsOutGoingOps,
 	})
 	if err != nil {
 		log.Error("sovereignSubRoundEnd.ReceivedProof", "error", err)

--- a/consensus/spos/bls/sovereign/sovereignSubRoundEnd.go
+++ b/consensus/spos/bls/sovereign/sovereignSubRoundEnd.go
@@ -65,6 +65,16 @@ func (sr *sovereignSubRoundEnd) receivedBlockHeaderFinalInfo(ctx context.Context
 func (sr *sovereignSubRoundEnd) ReceivedProof(proof consensus.ProofHandler) {
 	sr.subroundEndRoundV2.ReceivedProof(proof)
 
+	err := sr.updateOutGoingPoolIfNeeded(&consensus.Message{
+		PubKeysBitmap:   proof.GetPubKeysBitmap(),
+		ExtraSignatures: getExtraSigsOutGoingOps(proof),
+	})
+	if err != nil {
+		log.Error("sovereignSubRoundEnd.ReceivedProof", "error", err)
+	}
+}
+
+func getExtraSigsOutGoingOps(proof consensus.ProofHandler) map[string]*consensus.ExtraSignatureData {
 	extraSigsOutGoingOps := make(map[string]*consensus.ExtraSignatureData)
 
 	for id, sigData := range proof.GetExtraSignatureHandlers() {
@@ -74,13 +84,7 @@ func (sr *sovereignSubRoundEnd) ReceivedProof(proof consensus.ProofHandler) {
 		}
 	}
 
-	err := sr.updateOutGoingPoolIfNeeded(&consensus.Message{
-		PubKeysBitmap:   proof.GetPubKeysBitmap(),
-		ExtraSignatures: extraSigsOutGoingOps,
-	})
-	if err != nil {
-		log.Error("sovereignSubRoundEnd.ReceivedProof", "error", err)
-	}
+	return extraSigsOutGoingOps
 }
 
 func (sr *sovereignSubRoundEnd) updateOutGoingPoolIfNeeded(cnsDta *consensus.Message) error {

--- a/consensus/spos/bls/v2/blsSubroundsFactory.go
+++ b/consensus/spos/bls/v2/blsSubroundsFactory.go
@@ -327,8 +327,7 @@ func (fct *factory) GenerateEndRoundSubround() (bls.SubRoundEndHandler, error) {
 		return nil, err
 	}
 
-	// TODO: MX-17039 REVERT THIS BACK
-	//fct.worker.AddReceivedProofHandler(subroundEndRoundObject.receivedProof)
+	fct.worker.AddReceivedProofHandler(subroundEndRoundObject.receivedProof)
 	fct.worker.AddReceivedMessageCall(bls.MtInvalidSigners, subroundEndRoundObject.receivedInvalidSignersInfo)
 	fct.worker.AddReceivedMessageCall(bls.MtSignature, subroundEndRoundObject.receivedSignature)
 

--- a/consensus/spos/bls/v2/blsSubroundsFactory.go
+++ b/consensus/spos/bls/v2/blsSubroundsFactory.go
@@ -219,6 +219,7 @@ func (fct *factory) GenerateBlockSubround() (bls.SubRoundBlockHandler, error) {
 		subround,
 		processingThresholdPercent,
 		fct.worker,
+		fct.extraSignersHolder.GetSubRoundEndExtraSignersHolder(),
 	)
 	if err != nil {
 		return nil, err

--- a/consensus/spos/bls/v2/blsSubroundsFactory.go
+++ b/consensus/spos/bls/v2/blsSubroundsFactory.go
@@ -326,7 +326,8 @@ func (fct *factory) GenerateEndRoundSubround() (bls.SubRoundEndHandler, error) {
 		return nil, err
 	}
 
-	fct.worker.AddReceivedProofHandler(subroundEndRoundObject.receivedProof)
+	// TODO: MX-17039 REVERT THIS BACK
+	//fct.worker.AddReceivedProofHandler(subroundEndRoundObject.receivedProof)
 	fct.worker.AddReceivedMessageCall(bls.MtInvalidSigners, subroundEndRoundObject.receivedInvalidSignersInfo)
 	fct.worker.AddReceivedMessageCall(bls.MtSignature, subroundEndRoundObject.receivedSignature)
 

--- a/consensus/spos/bls/v2/export_test.go
+++ b/consensus/spos/bls/v2/export_test.go
@@ -257,8 +257,8 @@ func (sr *subroundEndRound) DoEndRoundJobByNode() bool {
 }
 
 // CreateAndBroadcastProof calls the unexported createAndBroadcastHeaderFinalInfo function
-func (sr *subroundEndRound) CreateAndBroadcastProof(signature []byte, bitmap []byte) {
-	_ = sr.createAndBroadcastProof(signature, bitmap, "sender")
+func (sr *subroundEndRound) CreateAndBroadcastProof(signature []byte, bitmap []byte, extraAggregatedSigs map[string][]byte) {
+	_ = sr.createAndBroadcastProof(signature, bitmap, "sender", extraAggregatedSigs)
 }
 
 // IsOutOfTime calls the unexported isOutOfTime function

--- a/consensus/spos/bls/v2/subroundBlock.go
+++ b/consensus/spos/bls/v2/subroundBlock.go
@@ -15,6 +15,7 @@ import (
 	"github.com/multiversx/mx-chain-go/consensus"
 	"github.com/multiversx/mx-chain-go/consensus/spos"
 	"github.com/multiversx/mx-chain-go/consensus/spos/bls"
+	"github.com/multiversx/mx-chain-go/errors"
 )
 
 // maxAllowedSizeInBytes defines how many bytes are allowed as payload in a message
@@ -28,6 +29,7 @@ type subroundBlock struct {
 	worker                        spos.WorkerHandler
 	mutBlockProcessing            sync.Mutex
 	enableEpochHandler            common.EnableEpochsHandler
+	extraSignersHolder            bls.SubRoundEndExtraSignersHolder
 }
 
 // NewSubroundBlock creates a subroundBlock object
@@ -35,6 +37,7 @@ func NewSubroundBlock(
 	baseSubround *spos.Subround,
 	processingThresholdPercentage int,
 	worker spos.WorkerHandler,
+	extraSignersHolder bls.SubRoundEndExtraSignersHolder,
 ) (*subroundBlock, error) {
 	err := checkNewSubroundBlockParams(baseSubround)
 	if err != nil {
@@ -44,12 +47,16 @@ func NewSubroundBlock(
 	if check.IfNil(worker) {
 		return nil, spos.ErrNilWorker
 	}
+	if check.IfNil(extraSignersHolder) {
+		return nil, errors.ErrNilEndRoundExtraSignersHolder
+	}
 
 	srBlock := subroundBlock{
 		Subround:                      baseSubround,
 		processingThresholdPercentage: processingThresholdPercentage,
 		worker:                        worker,
 		enableEpochHandler:            baseSubround.EnableEpochsHandler(),
+		extraSignersHolder:            extraSignersHolder,
 	}
 
 	srBlock.Job = srBlock.doBlockJob
@@ -134,7 +141,7 @@ func (sr *subroundBlock) DoBlockComputation(ctx context.Context) (*bls.SubRoundB
 	// TODO: MX-17039- check here for extra signers maybe from sub round end round
 
 	// block proof verification should be done over the header that contains the leader signature
-	leaderSignature, err := sr.signBlockHeader(header)
+	leaderPubKey, leaderSignature, err := sr.signBlockHeader(header)
 	if err != nil {
 		printLogMessage(ctx, "doBlockJob.signBlockHeader", err)
 		return nil, func() {}
@@ -143,6 +150,12 @@ func (sr *subroundBlock) DoBlockComputation(ctx context.Context) (*bls.SubRoundB
 	err = header.SetLeaderSignature(leaderSignature)
 	if err != nil {
 		printLogMessage(ctx, "doBlockJob.SetLeaderSignature", err)
+		return nil, func() {}
+	}
+
+	err = sr.extraSignersHolder.SignAndSetLeaderSignature(header, leaderPubKey)
+	if err != nil {
+		log.Debug("doEndRoundJobByLeader.extraSignatureAggregator.SignAndSetLeaderSignature", "error", err.Error())
 		return nil, func() {}
 	}
 
@@ -164,24 +177,30 @@ func (sr *subroundBlock) DoBlockComputation(ctx context.Context) (*bls.SubRoundB
 	}, deferFunc
 }
 
-func (sr *subroundBlock) signBlockHeader(header data.HeaderHandler) ([]byte, error) {
+func (sr *subroundBlock) signBlockHeader(header data.HeaderHandler) ([]byte, []byte, error) {
 	headerClone := header.ShallowClone()
 	err := headerClone.SetLeaderSignature(nil)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	marshalledHdr, err := sr.Marshalizer().Marshal(headerClone)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	leader, errGetLeader := sr.GetLeader()
 	if errGetLeader != nil {
-		return nil, errGetLeader
+		return nil, nil, errGetLeader
 	}
 
-	return sr.SigningHandler().CreateSignatureForPublicKey(marshalledHdr, []byte(leader))
+	leaderPubKey := []byte(leader)
+	leaderSignature, err := sr.SigningHandler().CreateSignatureForPublicKey(marshalledHdr, leaderPubKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return leaderPubKey, leaderSignature, nil
 }
 
 func printLogMessage(ctx context.Context, baseMessage string, err error) {

--- a/consensus/spos/bls/v2/subroundBlock.go
+++ b/consensus/spos/bls/v2/subroundBlock.go
@@ -138,8 +138,6 @@ func (sr *subroundBlock) DoBlockComputation(ctx context.Context) (*bls.SubRoundB
 		return nil, func() {}
 	}
 
-	// TODO: MX-17039- check here for extra signers maybe from sub round end round
-
 	// block proof verification should be done over the header that contains the leader signature
 	leaderPubKey, leaderSignature, err := sr.signBlockHeader(header)
 	if err != nil {

--- a/consensus/spos/bls/v2/subroundBlock_test.go
+++ b/consensus/spos/bls/v2/subroundBlock_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/multiversx/mx-chain-go/consensus/spos"
 	"github.com/multiversx/mx-chain-go/consensus/spos/bls"
 	v2 "github.com/multiversx/mx-chain-go/consensus/spos/bls/v2"
+	errMx "github.com/multiversx/mx-chain-go/errors"
 	"github.com/multiversx/mx-chain-go/sharding/nodesCoordinator"
 	"github.com/multiversx/mx-chain-go/testscommon"
 	consensusMocks "github.com/multiversx/mx-chain-go/testscommon/consensus"
@@ -28,6 +29,7 @@ import (
 	"github.com/multiversx/mx-chain-go/testscommon/enableEpochsHandlerMock"
 	"github.com/multiversx/mx-chain-go/testscommon/shardingMocks"
 	"github.com/multiversx/mx-chain-go/testscommon/statusHandler"
+	"github.com/multiversx/mx-chain-go/testscommon/subRounds"
 )
 
 var expectedErr = errors.New("expected error")
@@ -71,6 +73,7 @@ func defaultSubroundBlockFromSubround(sr *spos.Subround) (v2.SubroundBlock, erro
 		sr,
 		v2.ProcessingThresholdPercent,
 		&consensusMocks.SposWorkerMock{},
+		&subRounds.SubRoundEndExtraSignersHolderMock{},
 	)
 
 	return srBlock, err
@@ -81,6 +84,7 @@ func defaultSubroundBlockWithoutErrorFromSubround(sr *spos.Subround) v2.Subround
 		sr,
 		v2.ProcessingThresholdPercent,
 		&consensusMocks.SposWorkerMock{},
+		&subRounds.SubRoundEndExtraSignersHolderMock{},
 	)
 
 	return srBlock
@@ -162,9 +166,27 @@ func TestSubroundBlock_NewSubroundBlockNilSubroundShouldFail(t *testing.T) {
 		nil,
 		v2.ProcessingThresholdPercent,
 		&consensusMocks.SposWorkerMock{},
+		&subRounds.SubRoundEndExtraSignersHolderMock{},
 	)
 	assert.Nil(t, srBlock)
 	assert.Equal(t, spos.ErrNilSubround, err)
+}
+
+func TestSubroundBlock_NewSubroundBlockNilExtraSignerHolderShouldFail(t *testing.T) {
+	t.Parallel()
+
+	container := consensusMocks.InitConsensusCore()
+	consensusState := initializers.InitConsensusState()
+	ch := make(chan bool, 1)
+	sr, _ := defaultSubroundForSRBlock(consensusState, ch, container, &statusHandler.AppStatusHandlerStub{})
+	srBlock, err := v2.NewSubroundBlock(
+		sr,
+		v2.ProcessingThresholdPercent,
+		&consensusMocks.SposWorkerMock{},
+		nil,
+	)
+	require.Nil(t, srBlock)
+	require.Equal(t, errMx.ErrNilEndRoundExtraSignersHolder, err)
 }
 
 func TestSubroundBlock_NewSubroundBlockNilBlockchainShouldFail(t *testing.T) {
@@ -316,6 +338,7 @@ func TestSubroundBlock_NewSubroundBlockNilWorkerShouldFail(t *testing.T) {
 		sr,
 		v2.ProcessingThresholdPercent,
 		nil,
+		&subRounds.SubRoundEndExtraSignersHolderMock{},
 	)
 	assert.Nil(t, srBlock)
 	assert.Equal(t, spos.ErrNilWorker, err)
@@ -569,6 +592,7 @@ func TestSubroundBlock_DoBlockJob(t *testing.T) {
 			baseSr,
 			v2.ProcessingThresholdPercent,
 			&consensusMocks.SposWorkerMock{},
+			&subRounds.SubRoundEndExtraSignersHolderMock{},
 		)
 
 		providedLeaderSignature := []byte("leader signature")

--- a/consensus/spos/bls/v2/subroundEndRound.go
+++ b/consensus/spos/bls/v2/subroundEndRound.go
@@ -693,7 +693,7 @@ func (sr *subroundEndRound) createAndBroadcastProof(
 	headerProof := &block.HeaderProof{
 		PubKeysBitmap:       bitmap,
 		AggregatedSignature: signature,
-		HeaderHash:          sr.getMessageToVerifySig(), // THIS ACTUALLY NEEDS TO USE THE CORRECT HASH
+		HeaderHash:          sr.getMessageToVerifySig(), // MX-17040: THIS ACTUALLY NEEDS TO USE THE CORRECT HASH
 		HeaderEpoch:         sr.GetHeader().GetEpoch(),
 		HeaderNonce:         sr.GetHeader().GetNonce(),
 		HeaderShardId:       sr.GetHeader().GetShardID(),

--- a/consensus/spos/bls/v2/subroundEndRound.go
+++ b/consensus/spos/bls/v2/subroundEndRound.go
@@ -672,12 +672,19 @@ func (sr *subroundEndRound) createAndBroadcastProof(
 		return ErrProofAlreadyPropagated
 	}
 
+	// Iterate over outgoing mbs and add in map below, along with operation hash
 	extraSigs := make(map[string]*block.ExtraSignatureData)
 	for id, aggSig := range extraAggregatedSigs {
+		if len(aggSig) == 0 {
+			continue
+		}
+
 		extraSigs[id] = &block.ExtraSignatureData{
-			SignatureShare:      aggSig,
-			AggregatedSignature: nil,
+			// TODO: MX-17039 I think we need to remove SignatureShare from this proof
+			SignatureShare:      nil,
+			AggregatedSignature: aggSig,
 			LeaderSignature:     nil,
+			//OperationHash: ?
 		}
 	}
 

--- a/consensus/spos/bls/v2/subroundEndRound.go
+++ b/consensus/spos/bls/v2/subroundEndRound.go
@@ -672,22 +672,9 @@ func (sr *subroundEndRound) createAndBroadcastProof(
 		return ErrProofAlreadyPropagated
 	}
 
-	// Iterate over outgoing mbs and add in map below, along with operation hash
-	extraSigs := make(map[string]*block.ExtraSignatureData)
-	for id, aggSig := range extraAggregatedSigs {
-		if len(aggSig) == 0 {
-			continue
-		}
-
-		leaderSig, err := sr.extraSignersHolder.GetLeaderExtraSig(sr.GetHeader(), id)
-		if err != nil {
-			return err
-		}
-
-		extraSigs[id] = &block.ExtraSignatureData{
-			AggregatedSignature: aggSig,
-			LeaderSignature:     leaderSig,
-		}
+	extraSigs, err := sr.prepareExtraSignaturesForProof(extraAggregatedSigs)
+	if err != nil {
+		return err
 	}
 
 	headerProof := &block.HeaderProof{
@@ -702,7 +689,7 @@ func (sr *subroundEndRound) createAndBroadcastProof(
 		ExtraSignatures:     extraSigs,
 	}
 
-	err := sr.BroadcastMessenger().BroadcastEquivalentProof(headerProof, []byte(sender))
+	err = sr.BroadcastMessenger().BroadcastEquivalentProof(headerProof, []byte(sender))
 	if err != nil {
 		return err
 	}
@@ -713,6 +700,27 @@ func (sr *subroundEndRound) createAndBroadcastProof(
 		"proof sender", hex.EncodeToString([]byte(sender)))
 
 	return nil
+}
+
+func (sr *subroundEndRound) prepareExtraSignaturesForProof(extraAggregatedSigs map[string][]byte) (map[string]*block.ExtraSignatureData, error) {
+	extraSigs := make(map[string]*block.ExtraSignatureData)
+	for id, aggSig := range extraAggregatedSigs {
+		if len(aggSig) == 0 {
+			continue
+		}
+
+		leaderSig, err := sr.extraSignersHolder.GetLeaderExtraSig(sr.GetHeader(), id)
+		if err != nil {
+			return nil, err
+		}
+
+		extraSigs[id] = &block.ExtraSignatureData{
+			AggregatedSignature: aggSig,
+			LeaderSignature:     leaderSig,
+		}
+	}
+
+	return extraSigs, nil
 }
 
 func (sr *subroundEndRound) getEquivalentProofSender() string {

--- a/consensus/spos/bls/v2/subroundEndRound.go
+++ b/consensus/spos/bls/v2/subroundEndRound.go
@@ -679,12 +679,14 @@ func (sr *subroundEndRound) createAndBroadcastProof(
 			continue
 		}
 
+		leaderSig, err := sr.extraSignersHolder.GetLeaderExtraSig(sr.GetHeader(), id)
+		if err != nil {
+			return err
+		}
+
 		extraSigs[id] = &block.ExtraSignatureData{
-			// TODO: MX-17039 I think we need to remove SignatureShare from this proof
-			SignatureShare:      nil,
 			AggregatedSignature: aggSig,
-			LeaderSignature:     nil,
-			//OperationHash: ?
+			LeaderSignature:     leaderSig,
 		}
 	}
 

--- a/consensus/spos/bls/v2/subroundEndRound.go
+++ b/consensus/spos/bls/v2/subroundEndRound.go
@@ -400,14 +400,8 @@ func (sr *subroundEndRound) sendProof() (bool, error) {
 		return false, ErrTimeOut
 	}
 
-	// TODO: MX-17039-this signature should be added in proof in createAndBroadcastProof, instead of being added in header
-	err = sr.extraSignersHolder.SetAggregatedSignatureInHeader(sr.GetHeader(), aggSigsRes.extraAggregatedSigs)
-	if err != nil {
-		return false, err
-	}
-
 	// broadcast header proof
-	err = sr.createAndBroadcastProof(aggSigsRes.aggregatedSig, bitmap, currentSender)
+	err = sr.createAndBroadcastProof(aggSigsRes.aggregatedSig, bitmap, currentSender, aggSigsRes.extraAggregatedSigs)
 	if err != nil && !errors.Is(err, ErrProofAlreadyPropagated) {
 		log.Warn("sendProof.createAndBroadcastProof", "error", err.Error())
 	}
@@ -671,22 +665,32 @@ func (sr *subroundEndRound) createAndBroadcastProof(
 	signature []byte,
 	bitmap []byte,
 	sender string,
+	extraAggregatedSigs map[string][]byte,
 ) error {
 	if sr.EquivalentProofsPool().HasProof(sr.ShardCoordinator().SelfId(), sr.getMessageToVerifySig()) {
 		// no need to broadcast a proof if already received and verified one
 		return ErrProofAlreadyPropagated
 	}
 
+	extraSigs := make(map[string]*block.ExtraSignatureData)
+	for id, aggSig := range extraAggregatedSigs {
+		extraSigs[id] = &block.ExtraSignatureData{
+			SignatureShare:      aggSig,
+			AggregatedSignature: nil,
+			LeaderSignature:     nil,
+		}
+	}
+
 	headerProof := &block.HeaderProof{
 		PubKeysBitmap:       bitmap,
 		AggregatedSignature: signature,
-		HeaderHash:          sr.getMessageToVerifySig(),
+		HeaderHash:          sr.getMessageToVerifySig(), // THIS ACTUALLY NEEDS TO USE THE CORRECT HASH
 		HeaderEpoch:         sr.GetHeader().GetEpoch(),
 		HeaderNonce:         sr.GetHeader().GetNonce(),
 		HeaderShardId:       sr.GetHeader().GetShardID(),
 		HeaderRound:         sr.GetHeader().GetRound(),
 		IsStartOfEpoch:      sr.GetHeader().IsStartOfEpochBlock(),
-		// TODO: MX-17039- add extra aggregated sigs in proof
+		ExtraSignatures:     extraSigs,
 	}
 
 	err := sr.BroadcastMessenger().BroadcastEquivalentProof(headerProof, []byte(sender))

--- a/consensus/spos/bls/v2/subroundEndRound_test.go
+++ b/consensus/spos/bls/v2/subroundEndRound_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/multiversx/mx-chain-go/testscommon/p2pmocks"
 	"github.com/multiversx/mx-chain-go/testscommon/shardingMocks"
 	"github.com/multiversx/mx-chain-go/testscommon/statusHandler"
+	"github.com/multiversx/mx-chain-go/testscommon/subRounds"
 	"github.com/multiversx/mx-chain-go/testscommon/subRoundsHolder"
 )
 
@@ -710,19 +711,71 @@ func TestSubroundEndRound_CheckSignaturesValidityShouldReturnNil(t *testing.T) {
 func TestSubroundEndRound_CreateAndBroadcastProofShouldBeCalled(t *testing.T) {
 	t.Parallel()
 
+	extraAggSig := []byte("extraAggSig")
+	extraAggSigs := map[string][]byte{
+		block.OutGoingMbTx.String():                 extraAggSig,
+		block.OutGoingMbChangeValidatorSet.String(): nil,
+	}
+
 	chanRcv := make(chan bool, 1)
 	leaderSigInHdr := []byte("leader sig")
+	leaderExtraSig := []byte("leader extra sig")
 	container := consensusMocks.InitConsensusCore()
 	messenger := &consensusMocks.BroadcastMessengerMock{
 		BroadcastEquivalentProofCalled: func(proof data.HeaderProofHandler, pkBytes []byte) error {
+			require.Equal(t, map[string]data.ExtraSignatureDataHandler{
+				block.OutGoingMbTx.String(): &block.ExtraSignatureData{
+					AggregatedSignature: extraAggSig,
+					LeaderSignature:     leaderExtraSig,
+				},
+			}, proof.GetExtraSignatureHandlers())
+
 			chanRcv <- true
 			return nil
 		},
 	}
 	container.SetBroadcastMessenger(messenger)
-	sr := initSubroundEndRoundWithContainer(container, &statusHandler.AppStatusHandlerStub{})
-	sr.SetHeader(&block.Header{LeaderSignature: leaderSigInHdr})
-	sr.CreateAndBroadcastProof([]byte("sig"), []byte("bitmap"))
+
+	ch := make(chan bool, 1)
+	consensusState := initializers.InitConsensusStateWithNodesCoordinator(container.NodesCoordinator())
+	sr, _ := spos.NewSubround(
+		bls.SrSignature,
+		bls.SrEndRound,
+		-1,
+		int64(85*roundTimeDuration/100),
+		int64(95*roundTimeDuration/100),
+		"(END_ROUND)",
+		consensusState,
+		ch,
+		executeStoredMessages,
+		container,
+		chainID,
+		currentPid,
+		&statusHandler.AppStatusHandlerStub{},
+	)
+
+	extraSigHolder := &subRoundsHolder.ExtraSignersHolderMock{
+		GetSubRoundEndExtraSignersHolderCalled: func() bls.SubRoundEndExtraSignersHolder {
+			return &subRounds.SubRoundEndExtraSignersHolderMock{
+				GetLeaderExtraSigCalled: func(header data.HeaderHandler, id string) ([]byte, error) {
+					require.Equal(t, block.OutGoingMbTx.String(), id)
+					return leaderExtraSig, nil
+				},
+			}
+		},
+	}
+	srEndRound, _ := v2.NewSubroundEndRound(
+		sr,
+		v2.ProcessingThresholdPercent,
+		&statusHandler.AppStatusHandlerStub{},
+		&testscommon.SentSignatureTrackerStub{},
+		&consensusMocks.SposWorkerMock{},
+		&dataRetrieverMocks.ThrottlerStub{},
+		extraSigHolder,
+	)
+
+	srEndRound.SetHeader(&block.Header{LeaderSignature: leaderSigInHdr})
+	srEndRound.CreateAndBroadcastProof([]byte("sig"), []byte("bitmap"), extraAggSigs)
 
 	select {
 	case <-chanRcv:

--- a/consensus/spos/extraSigners/holders/errors.go
+++ b/consensus/spos/extraSigners/holders/errors.go
@@ -1,0 +1,7 @@
+package holders
+
+import (
+	"errors"
+)
+
+var errExtraSignerDoesNotExist = errors.New("extra signer does not exist")

--- a/consensus/spos/extraSigners/holders/subRoundEndExtraSignersHolder.go
+++ b/consensus/spos/extraSigners/holders/subRoundEndExtraSignersHolder.go
@@ -149,6 +149,19 @@ func (holder *subRoundEndExtraSignersHolder) HaveConsensusHeaderWithFullInfo(hea
 	return nil
 }
 
+// GetLeaderExtraSig calls GetLeaderExtraSig for the specified registered signer
+func (holder *subRoundEndExtraSignersHolder) GetLeaderExtraSig(header data.HeaderHandler, id string) ([]byte, error) {
+	holder.mutExtraSigners.RLock()
+	defer holder.mutExtraSigners.RUnlock()
+
+	extraSigner, found := holder.extraSigners[id]
+	if !found {
+		return nil, fmt.Errorf("%w for id: %s", errExtraSignerDoesNotExist, id)
+	}
+
+	return extraSigner.GetLeaderExtraSig(header)
+}
+
 // RegisterExtraSigningHandler calls RegisterExtraSigningHandler for all registered signers
 func (holder *subRoundEndExtraSignersHolder) RegisterExtraSigningHandler(extraSigner consensus.SubRoundEndExtraSignatureHandler) error {
 	if check.IfNil(extraSigner) {

--- a/consensus/spos/extraSigners/sovereignSubRoundEndExtraSigner.go
+++ b/consensus/spos/extraSigners/sovereignSubRoundEndExtraSigner.go
@@ -8,6 +8,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data/block"
 	logger "github.com/multiversx/mx-chain-logger-go"
 
+	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/consensus"
 	"github.com/multiversx/mx-chain-go/consensus/spos"
 	"github.com/multiversx/mx-chain-go/consensus/spos/bls"
@@ -17,22 +18,28 @@ import (
 var log = logger.GetOrCreate("extra-signers")
 
 type sovereignSubRoundEndOutGoingTxData struct {
-	signingHandler consensus.SigningHandler
-	mbType         block.OutGoingMBType
+	signingHandler      consensus.SigningHandler
+	mbType              block.OutGoingMBType
+	enableEpochsHandler common.EnableEpochsHandler
 }
 
 // NewSovereignSubRoundEndExtraSigner creates a new extra signer for sovereign outgoing mini blocks in end subround
 func NewSovereignSubRoundEndExtraSigner(
 	signingHandler consensus.SigningHandler,
 	mbType block.OutGoingMBType,
+	enableEpochsHandler common.EnableEpochsHandler,
 ) (*sovereignSubRoundEndOutGoingTxData, error) {
 	if check.IfNil(signingHandler) {
 		return nil, spos.ErrNilSigningHandler
 	}
+	if check.IfNil(enableEpochsHandler) {
+		return nil, spos.ErrNilEnableEpochHandler
+	}
 
 	return &sovereignSubRoundEndOutGoingTxData{
-		signingHandler: signingHandler,
-		mbType:         mbType,
+		signingHandler:      signingHandler,
+		mbType:              mbType,
+		enableEpochsHandler: enableEpochsHandler,
 	}, nil
 }
 
@@ -108,9 +115,12 @@ func (sr *sovereignSubRoundEndOutGoingTxData) SignAndSetLeaderSignature(header d
 		return nil
 	}
 
-	leaderMsgToSign := append(
-		outGoingMb.GetOutGoingOperationsHash(),
-		outGoingMb.GetAggregatedSignatureOutGoingOperations()...)
+	leaderMsgToSign := outGoingMb.GetOutGoingOperationsHash()
+
+	// In consensus v2 leader will only sign the outgoing op hash
+	if !sr.enableEpochsHandler.IsFlagEnabled(common.AndromedaFlag) {
+		leaderMsgToSign = append(leaderMsgToSign, outGoingMb.GetAggregatedSignatureOutGoingOperations()...)
+	}
 
 	leaderSig, err := sr.signingHandler.CreateSignatureForPublicKey(leaderMsgToSign, leaderPubKey)
 	if err != nil {

--- a/consensus/spos/extraSigners/sovereignSubRoundEndExtraSigner.go
+++ b/consensus/spos/extraSigners/sovereignSubRoundEndExtraSigner.go
@@ -164,6 +164,21 @@ func (sr *sovereignSubRoundEndOutGoingTxData) SetConsensusDataInHeader(header da
 	return sovHeader.SetOutGoingMiniBlockHeaderHandler(outGoingMb)
 }
 
+// GetLeaderExtraSig will return the leader extra sig from the header
+func (sr *sovereignSubRoundEndOutGoingTxData) GetLeaderExtraSig(header data.HeaderHandler) ([]byte, error) {
+	sovHeader, castOk := header.(data.SovereignChainHeaderHandler)
+	if !castOk {
+		return nil, fmt.Errorf("%w in sovereignSubRoundEndOutGoingTxData.SetConsensusDataInHeader", errors.ErrWrongTypeAssertion)
+	}
+
+	outGoingMb := sovHeader.GetOutGoingMiniBlockHeaderHandler(int32(sr.mbType))
+	if check.IfNil(outGoingMb) {
+		return nil, nil
+	}
+
+	return outGoingMb.GetLeaderSignatureOutGoingOperations(), nil
+}
+
 // AddLeaderAndAggregatedSignatures adds aggregated and leader signature in consensus message with provided data from header
 func (sr *sovereignSubRoundEndOutGoingTxData) AddLeaderAndAggregatedSignatures(header data.HeaderHandler, cnsMsg *consensus.Message) error {
 	sovHeader, castOk := header.(data.SovereignChainHeaderHandler)

--- a/consensus/spos/extraSigners/sovereignSubRoundEndExtraSigner.go
+++ b/consensus/spos/extraSigners/sovereignSubRoundEndExtraSigner.go
@@ -168,7 +168,7 @@ func (sr *sovereignSubRoundEndOutGoingTxData) SetConsensusDataInHeader(header da
 func (sr *sovereignSubRoundEndOutGoingTxData) GetLeaderExtraSig(header data.HeaderHandler) ([]byte, error) {
 	sovHeader, castOk := header.(data.SovereignChainHeaderHandler)
 	if !castOk {
-		return nil, fmt.Errorf("%w in sovereignSubRoundEndOutGoingTxData.SetConsensusDataInHeader", errors.ErrWrongTypeAssertion)
+		return nil, fmt.Errorf("%w in sovereignSubRoundEndOutGoingTxData.GetLeaderExtraSig", errors.ErrWrongTypeAssertion)
 	}
 
 	outGoingMb := sovHeader.GetOutGoingMiniBlockHeaderHandler(int32(sr.mbType))

--- a/consensus/spos/extraSigners/sovereignSubRoundEndExtraSigner_test.go
+++ b/consensus/spos/extraSigners/sovereignSubRoundEndExtraSigner_test.go
@@ -7,23 +7,25 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data/block"
 	"github.com/stretchr/testify/require"
 
+	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/consensus"
 	"github.com/multiversx/mx-chain-go/consensus/spos"
 	"github.com/multiversx/mx-chain-go/errors"
 	cnsTest "github.com/multiversx/mx-chain-go/testscommon/consensus"
+	"github.com/multiversx/mx-chain-go/testscommon/enableEpochsHandlerMock"
 )
 
 func TestNewSovereignSubRoundEndOutGoingTxData(t *testing.T) {
 	t.Parallel()
 
 	t.Run("nil signing handler, should return error", func(t *testing.T) {
-		sovSigHandler, err := NewSovereignSubRoundEndExtraSigner(nil, block.OutGoingMbTx)
+		sovSigHandler, err := NewSovereignSubRoundEndExtraSigner(nil, block.OutGoingMbTx, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
 		require.Equal(t, spos.ErrNilSigningHandler, err)
 		require.True(t, check.IfNil(sovSigHandler))
 	})
 
 	t.Run("should work", func(t *testing.T) {
-		sovSigHandler, err := NewSovereignSubRoundEndExtraSigner(&cnsTest.SigningHandlerStub{}, block.OutGoingMbTx)
+		sovSigHandler, err := NewSovereignSubRoundEndExtraSigner(&cnsTest.SigningHandlerStub{}, block.OutGoingMbTx, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
 		require.Nil(t, err)
 		require.False(t, sovSigHandler.IsInterfaceNil())
 	})
@@ -57,7 +59,7 @@ func TestSovereignSubRoundEndOutGoingTxData_VerifyAggregatedSignatures(t *testin
 			return nil
 		},
 	}
-	sovSigHandler, _ := NewSovereignSubRoundEndExtraSigner(signingHandler, block.OutGoingMbTx)
+	sovSigHandler, _ := NewSovereignSubRoundEndExtraSigner(signingHandler, block.OutGoingMbTx, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
 
 	t.Run("invalid header type, should return error", func(t *testing.T) {
 		err := sovSigHandler.VerifyAggregatedSignatures(expectedBitMap, sovHdr.Header)
@@ -115,7 +117,7 @@ func TestSovereignSubRoundEndOutGoingTxData_AggregateSignatures(t *testing.T) {
 			return nil
 		},
 	}
-	sovSigHandler, _ := NewSovereignSubRoundEndExtraSigner(signingHandler, block.OutGoingMbTx)
+	sovSigHandler, _ := NewSovereignSubRoundEndExtraSigner(signingHandler, block.OutGoingMbTx, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
 	result, err := sovSigHandler.AggregateAndSetSignatures(expectedBitMap, sovHdr)
 	require.Nil(t, err)
 	require.Equal(t, aggregatedSig, result)
@@ -137,7 +139,7 @@ func TestSovereignSubRoundEndOutGoingTxData_SeAggregatedSignatureInHeader(t *tes
 		},
 	}
 
-	sovSigHandler, _ := NewSovereignSubRoundEndExtraSigner(&cnsTest.SigningHandlerStub{}, block.OutGoingMbTx)
+	sovSigHandler, _ := NewSovereignSubRoundEndExtraSigner(&cnsTest.SigningHandlerStub{}, block.OutGoingMbTx, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
 
 	t.Run("invalid header type, should return error", func(t *testing.T) {
 		err := sovSigHandler.SetAggregatedSignatureInHeader(sovHdr.Header, aggregatedSig)
@@ -199,7 +201,8 @@ func TestSovereignSubRoundEndOutGoingTxData_SignAndSetLeaderSignature(t *testing
 			return expectedLeaderSig, nil
 		},
 	}
-	sovSigHandler, _ := NewSovereignSubRoundEndExtraSigner(signingHandler, block.OutGoingMbTx)
+
+	sovSigHandler, _ := NewSovereignSubRoundEndExtraSigner(signingHandler, block.OutGoingMbTx, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
 
 	t.Run("invalid header type, should return error", func(t *testing.T) {
 		err := sovSigHandler.SignAndSetLeaderSignature(sovHdr.Header, expectedLeaderPubKey)
@@ -214,7 +217,7 @@ func TestSovereignSubRoundEndOutGoingTxData_SignAndSetLeaderSignature(t *testing
 		require.Zero(t, verifyCalledCt)
 	})
 
-	t.Run("should create leader sig", func(t *testing.T) {
+	t.Run("should create leader sig with cns v1 version", func(t *testing.T) {
 		err := sovSigHandler.SignAndSetLeaderSignature(sovHdr, expectedLeaderPubKey)
 		require.Nil(t, err)
 		require.Equal(t, 1, verifyCalledCt)
@@ -232,6 +235,61 @@ func TestSovereignSubRoundEndOutGoingTxData_SignAndSetLeaderSignature(t *testing
 			},
 		}, sovHdr)
 	})
+}
+
+func TestSovereignSubRoundEndOutGoingTxData_SignAndSetLeaderSignatureInAndromeda(t *testing.T) {
+	t.Parallel()
+
+	outGoingOpHash := []byte("outGoingOpHash")
+	aggregatedSig := []byte("aggregatedSig")
+	sovHdr := &block.SovereignChainHeader{
+		Header: &block.Header{
+			Nonce: 4,
+			Epoch: 3,
+		},
+		OutGoingMiniBlockHeaders: []*block.OutGoingMiniBlockHeader{
+			{
+				OutGoingOperationsHash:                outGoingOpHash,
+				AggregatedSignatureOutGoingOperations: aggregatedSig,
+			},
+		},
+	}
+
+	createSignatureShareCalledCt := 0
+	expectedLeaderPubKey := []byte("leaderPubKey")
+	expectedLeaderSig := []byte("leaderSig")
+	signingHandler := &cnsTest.SigningHandlerStub{
+		CreateSignatureForPublicKeyCalled: func(message []byte, publicKeyBytes []byte) ([]byte, error) {
+			require.Equal(t, expectedLeaderPubKey, publicKeyBytes)
+			require.Equal(t, outGoingOpHash, message)
+
+			createSignatureShareCalledCt++
+			return expectedLeaderSig, nil
+		},
+	}
+
+	sovSigHandler, _ := NewSovereignSubRoundEndExtraSigner(
+		signingHandler,
+		block.OutGoingMbTx,
+		enableEpochsHandlerMock.NewEnableEpochsHandlerStub(common.AndromedaFlag),
+	)
+
+	err := sovSigHandler.SignAndSetLeaderSignature(sovHdr, expectedLeaderPubKey)
+	require.Nil(t, err)
+	require.Equal(t, 1, createSignatureShareCalledCt)
+	require.Equal(t, &block.SovereignChainHeader{
+		Header: &block.Header{
+			Nonce: 4,
+			Epoch: 3,
+		},
+		OutGoingMiniBlockHeaders: []*block.OutGoingMiniBlockHeader{
+			{
+				OutGoingOperationsHash:                outGoingOpHash,
+				AggregatedSignatureOutGoingOperations: aggregatedSig,
+				LeaderSignatureOutGoingOperations:     expectedLeaderSig,
+			},
+		},
+	}, sovHdr)
 }
 
 func TestSovereignSubRoundEndOutGoingTxData_HaveConsensusHeaderWithFullInfo(t *testing.T) {
@@ -261,7 +319,7 @@ func TestSovereignSubRoundEndOutGoingTxData_HaveConsensusHeaderWithFullInfo(t *t
 		},
 	}
 
-	sovSigHandler, _ := NewSovereignSubRoundEndExtraSigner(&cnsTest.SigningHandlerStub{}, block.OutGoingMbTx)
+	sovSigHandler, _ := NewSovereignSubRoundEndExtraSigner(&cnsTest.SigningHandlerStub{}, block.OutGoingMbTx, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
 
 	t.Run("invalid header type, should return error", func(t *testing.T) {
 		err := sovSigHandler.SetConsensusDataInHeader(sovHdr.Header, cnsMsg)
@@ -317,7 +375,7 @@ func TestSovereignSubRoundEndOutGoingTxData_AddLeaderAndAggregatedSignatures(t *
 		},
 	}
 
-	sovSigHandler, _ := NewSovereignSubRoundEndExtraSigner(&cnsTest.SigningHandlerStub{}, block.OutGoingMbTx)
+	sovSigHandler, _ := NewSovereignSubRoundEndExtraSigner(&cnsTest.SigningHandlerStub{}, block.OutGoingMbTx, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
 
 	t.Run("invalid header type, should return error", func(t *testing.T) {
 		err := sovSigHandler.AddLeaderAndAggregatedSignatures(sovHdr.Header, cnsMsg)
@@ -348,6 +406,6 @@ func TestSovereignSubRoundEndOutGoingTxData_AddLeaderAndAggregatedSignatures(t *
 
 func TestSovereignSubRoundEndOutGoingTxData_Identifier(t *testing.T) {
 	t.Parallel()
-	sovSigHandler, _ := NewSovereignSubRoundEndExtraSigner(&cnsTest.SigningHandlerStub{}, block.OutGoingMbTx)
+	sovSigHandler, _ := NewSovereignSubRoundEndExtraSigner(&cnsTest.SigningHandlerStub{}, block.OutGoingMbTx, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
 	require.Equal(t, block.OutGoingMbTx.String(), sovSigHandler.Identifier())
 }

--- a/consensus/spos/interface.go
+++ b/consensus/spos/interface.go
@@ -107,6 +107,7 @@ type WorkerHandler interface {
 	RemoveAllReceivedHeaderHandlers()
 	// AddReceivedProofHandler adds a new handler function for a received proof
 	AddReceivedProofHandler(handler func(consensus.ProofHandler))
+	ResetReceivedProofHandler()
 	// RemoveAllReceivedMessagesCalls removes all the functions handlers
 	RemoveAllReceivedMessagesCalls()
 	// ProcessReceivedMessage method redirects the received message to the channel which should handle it

--- a/consensus/spos/worker.go
+++ b/consensus/spos/worker.go
@@ -423,6 +423,13 @@ func (wrk *Worker) AddReceivedProofHandler(handler func(proofHandler consensus.P
 	wrk.mutReceivedProofHandler.Unlock()
 }
 
+// ResetReceivedProofHandler resets all received proof handlers
+func (wrk *Worker) ResetReceivedProofHandler() {
+	wrk.mutReceivedProofHandler.Lock()
+	wrk.receivedProofHandlers = make([]func(proofHandler consensus.ProofHandler), 0)
+	wrk.mutReceivedProofHandler.Unlock()
+}
+
 func (wrk *Worker) initReceivedMessages() {
 	wrk.mutReceivedMessages.Lock()
 	wrk.receivedMessages = wrk.consensusService.InitReceivedMessages()

--- a/epochStart/bootstrap/epochStartMetaBlockProcessor.go
+++ b/epochStart/bootstrap/epochStartMetaBlockProcessor.go
@@ -323,7 +323,7 @@ func (e *epochStartMetaBlockProcessor) requestProofForMetaBlock(metablockHash []
 	return nil
 }
 
-// TODO: MX-17039 check this one as well
+// TODO: MX-17040 check this one as well
 func (e *epochStartMetaBlockProcessor) receivedProof(proof dataCore.HeaderProofHandler) {
 	startOfEpochMetaBlock, hash, err := e.getMostReceivedMetaBlock()
 	if err != nil {

--- a/epochStart/shardchain/trigger.go
+++ b/epochStart/shardchain/trigger.go
@@ -562,7 +562,7 @@ func (t *trigger) changeEpochFinalityAttestingRoundIfNeeded(
 	t.epochFinalityAttestingRound = metaHdr.GetRound()
 }
 
-// TODO: MX-17039 integrate this in sovereign
+// TODO: MX-17040 integrate this in sovereign
 func (t *trigger) receivedProof(headerProof data.HeaderProofHandler) {
 	if check.IfNil(headerProof) {
 		return

--- a/factory/interface.go
+++ b/factory/interface.go
@@ -14,7 +14,6 @@ import (
 	"github.com/multiversx/mx-chain-core-go/hashing"
 	"github.com/multiversx/mx-chain-core-go/marshal"
 	crypto "github.com/multiversx/mx-chain-crypto-go"
-	"github.com/multiversx/mx-chain-go/sharding/chainParamFactory"
 	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
 
 	"github.com/multiversx/mx-chain-go/cmd/node/factory"
@@ -66,6 +65,7 @@ import (
 	"github.com/multiversx/mx-chain-go/process/track"
 	txSimData "github.com/multiversx/mx-chain-go/process/transactionEvaluator/data"
 	"github.com/multiversx/mx-chain-go/sharding"
+	"github.com/multiversx/mx-chain-go/sharding/chainParamFactory"
 	"github.com/multiversx/mx-chain-go/sharding/nodesCoordinator"
 	"github.com/multiversx/mx-chain-go/state"
 	syncerFactory "github.com/multiversx/mx-chain-go/state/syncer/factory"
@@ -431,6 +431,7 @@ type ConsensusWorker interface {
 	RemoveAllReceivedHeaderHandlers()
 	// AddReceivedProofHandler adds a new handler function for a received proof
 	AddReceivedProofHandler(handler func(proofHandler consensus.ProofHandler))
+	ResetReceivedProofHandler()
 	// RemoveAllReceivedMessagesCalls removes all the functions handlers
 	RemoveAllReceivedMessagesCalls()
 	// ProcessReceivedMessage method redirects the received message to the channel which should handle it

--- a/factory/runType/sovereignRunTypeComponents.go
+++ b/factory/runType/sovereignRunTypeComponents.go
@@ -189,7 +189,7 @@ func (rcf *sovereignRunTypeComponentsFactory) Create() (*runTypeComponents, erro
 
 	expiryTime := time.Second * time.Duration(rcf.sovConfig.OutgoingSubscribedEvents.TimeToWaitForUnconfirmedOutGoingOperationInSeconds)
 
-	sovHeaderSigVerifier, err := headerCheck.NewSovereignHeaderSigVerifier(rcf.cryptoComponents.BlockSigner())
+	sovHeaderSigVerifier, err := headerCheck.NewSovereignHeaderSigVerifier(rcf.cryptoComponents.BlockSigner(), rcf.coreComponents.EnableEpochsHandler())
 	if err != nil {
 		return nil, fmt.Errorf("sovereignRunTypeComponentsFactory - NewSovereignHeaderSigVerifier failed: %w", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/multiversx/mx-chain-go
 
 replace (
-	github.com/multiversx/mx-chain-core-go => github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20250715130233-f0b1f811a63c
+	github.com/multiversx/mx-chain-core-go => github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20250717104018-b2f858f6cc73
 	github.com/multiversx/mx-chain-es-indexer-go => github.com/multiversx/mx-chain-es-indexer-sovereign-go v1.7.17-0.20250715151725-0c18a314d0ea
 	github.com/multiversx/mx-chain-vm-common-go => github.com/multiversx/mx-chain-vm-common-sovereign-go v1.5.17-0.20250715144941-88820f3a7c28
 )

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/multiversx/mx-chain-go
 
 replace (
-	github.com/multiversx/mx-chain-core-go => github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20250717104018-b2f858f6cc73
+	github.com/multiversx/mx-chain-core-go => github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20250718131840-b5bbda5883ff
 	github.com/multiversx/mx-chain-es-indexer-go => github.com/multiversx/mx-chain-es-indexer-sovereign-go v1.7.17-0.20250715151725-0c18a314d0ea
 	github.com/multiversx/mx-chain-vm-common-go => github.com/multiversx/mx-chain-vm-common-sovereign-go v1.5.17-0.20250715144941-88820f3a7c28
 )

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/multiversx/mx-chain-go
 
 replace (
-	github.com/multiversx/mx-chain-core-go => github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20250718131840-b5bbda5883ff
+	github.com/multiversx/mx-chain-core-go => github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20250721142417-a7cdfedb7acf
 	github.com/multiversx/mx-chain-es-indexer-go => github.com/multiversx/mx-chain-es-indexer-sovereign-go v1.7.17-0.20250715151725-0c18a314d0ea
 	github.com/multiversx/mx-chain-vm-common-go => github.com/multiversx/mx-chain-vm-common-sovereign-go v1.5.17-0.20250715144941-88820f3a7c28
 )

--- a/go.sum
+++ b/go.sum
@@ -405,8 +405,8 @@ github.com/multiversx/concurrent-map v0.1.4 h1:hdnbM8VE4b0KYJaGY5yJS2aNIW9TFFsUY
 github.com/multiversx/concurrent-map v0.1.4/go.mod h1:8cWFRJDOrWHOTNSqgYCUvwT7c7eFQ4U2vKMOp4A/9+o=
 github.com/multiversx/mx-chain-communication-go v1.3.0 h1:ziNM1dRuiR/7al2L/jGEA/a/hjurtJ/HEqgazHNt9P8=
 github.com/multiversx/mx-chain-communication-go v1.3.0/go.mod h1:gDVWn6zUW6aCN1YOm/FbbT5MUmhgn/L1Rmpl8EoH3Yg=
-github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20250718131840-b5bbda5883ff h1:kcdGTCdZHroOtzkZjddF3FxYyMdWkIR9+0OwoswF32k=
-github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20250718131840-b5bbda5883ff/go.mod h1:cJw3+5HfcHb5uIf3f/0cjYBXq6jumM3TNeQAY8UQFF0=
+github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20250721142417-a7cdfedb7acf h1:oH6CVMquUg2bYSC8Bkfbe2cAtG7Bd5sRgRfmQ/1l304=
+github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20250721142417-a7cdfedb7acf/go.mod h1:cJw3+5HfcHb5uIf3f/0cjYBXq6jumM3TNeQAY8UQFF0=
 github.com/multiversx/mx-chain-crypto-go v1.3.0 h1:0eK2bkDOMi8VbSPrB1/vGJSYT81IBtfL4zw+C4sWe/k=
 github.com/multiversx/mx-chain-crypto-go v1.3.0/go.mod h1:nPIkxxzyTP8IquWKds+22Q2OJ9W7LtusC7cAosz7ojM=
 github.com/multiversx/mx-chain-es-indexer-sovereign-go v1.7.17-0.20250715151725-0c18a314d0ea h1:7h+IaMocTIwcJPqgQdAITL4UYaY+ZllfC9dldMrkbXk=

--- a/go.sum
+++ b/go.sum
@@ -405,8 +405,8 @@ github.com/multiversx/concurrent-map v0.1.4 h1:hdnbM8VE4b0KYJaGY5yJS2aNIW9TFFsUY
 github.com/multiversx/concurrent-map v0.1.4/go.mod h1:8cWFRJDOrWHOTNSqgYCUvwT7c7eFQ4U2vKMOp4A/9+o=
 github.com/multiversx/mx-chain-communication-go v1.3.0 h1:ziNM1dRuiR/7al2L/jGEA/a/hjurtJ/HEqgazHNt9P8=
 github.com/multiversx/mx-chain-communication-go v1.3.0/go.mod h1:gDVWn6zUW6aCN1YOm/FbbT5MUmhgn/L1Rmpl8EoH3Yg=
-github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20250717104018-b2f858f6cc73 h1:6xvxiEkBk1L+QbVZreKcwjBy/f8MgQ7kaH7TLc+kXjY=
-github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20250717104018-b2f858f6cc73/go.mod h1:cJw3+5HfcHb5uIf3f/0cjYBXq6jumM3TNeQAY8UQFF0=
+github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20250718131840-b5bbda5883ff h1:kcdGTCdZHroOtzkZjddF3FxYyMdWkIR9+0OwoswF32k=
+github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20250718131840-b5bbda5883ff/go.mod h1:cJw3+5HfcHb5uIf3f/0cjYBXq6jumM3TNeQAY8UQFF0=
 github.com/multiversx/mx-chain-crypto-go v1.3.0 h1:0eK2bkDOMi8VbSPrB1/vGJSYT81IBtfL4zw+C4sWe/k=
 github.com/multiversx/mx-chain-crypto-go v1.3.0/go.mod h1:nPIkxxzyTP8IquWKds+22Q2OJ9W7LtusC7cAosz7ojM=
 github.com/multiversx/mx-chain-es-indexer-sovereign-go v1.7.17-0.20250715151725-0c18a314d0ea h1:7h+IaMocTIwcJPqgQdAITL4UYaY+ZllfC9dldMrkbXk=

--- a/go.sum
+++ b/go.sum
@@ -405,8 +405,8 @@ github.com/multiversx/concurrent-map v0.1.4 h1:hdnbM8VE4b0KYJaGY5yJS2aNIW9TFFsUY
 github.com/multiversx/concurrent-map v0.1.4/go.mod h1:8cWFRJDOrWHOTNSqgYCUvwT7c7eFQ4U2vKMOp4A/9+o=
 github.com/multiversx/mx-chain-communication-go v1.3.0 h1:ziNM1dRuiR/7al2L/jGEA/a/hjurtJ/HEqgazHNt9P8=
 github.com/multiversx/mx-chain-communication-go v1.3.0/go.mod h1:gDVWn6zUW6aCN1YOm/FbbT5MUmhgn/L1Rmpl8EoH3Yg=
-github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20250715130233-f0b1f811a63c h1:ZhilBzxTxn6vvG0Y7A5fBTLUAwXiHuZ/TCscIC4sDCE=
-github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20250715130233-f0b1f811a63c/go.mod h1:cJw3+5HfcHb5uIf3f/0cjYBXq6jumM3TNeQAY8UQFF0=
+github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20250717104018-b2f858f6cc73 h1:6xvxiEkBk1L+QbVZreKcwjBy/f8MgQ7kaH7TLc+kXjY=
+github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20250717104018-b2f858f6cc73/go.mod h1:cJw3+5HfcHb5uIf3f/0cjYBXq6jumM3TNeQAY8UQFF0=
 github.com/multiversx/mx-chain-crypto-go v1.3.0 h1:0eK2bkDOMi8VbSPrB1/vGJSYT81IBtfL4zw+C4sWe/k=
 github.com/multiversx/mx-chain-crypto-go v1.3.0/go.mod h1:nPIkxxzyTP8IquWKds+22Q2OJ9W7LtusC7cAosz7ojM=
 github.com/multiversx/mx-chain-es-indexer-sovereign-go v1.7.17-0.20250715151725-0c18a314d0ea h1:7h+IaMocTIwcJPqgQdAITL4UYaY+ZllfC9dldMrkbXk=

--- a/process/block/baseProcess.go
+++ b/process/block/baseProcess.go
@@ -503,15 +503,13 @@ func displayHeader(
 				"",
 				"Nonce",
 				fmt.Sprintf("%d", proofNonce)}),
+			display.NewLineData(true, []string{
+				"",
+				"IsStartOfEpoch",
+				fmt.Sprintf("%t", isStartOfEpoch)}),
 		)
 
 		logLines = displayProofsExtraSignatures(logLines, headerProof.GetExtraSignatureHandlers())
-
-		logLines = append(logLines, display.NewLineData(true, []string{
-			"",
-			"IsStartOfEpoch",
-			fmt.Sprintf("%t", isStartOfEpoch)}),
-		)
 	}
 
 	return logLines
@@ -539,7 +537,7 @@ func displayProofExtraSignatures(
 	}
 
 	lines = append(lines, display.NewLineData(false, []string{
-		"Extra signature",
+		"Header proof extra signature",
 		"ID",
 		id}),
 	)

--- a/process/block/baseProcess.go
+++ b/process/block/baseProcess.go
@@ -1636,6 +1636,8 @@ func (bp *baseProcessor) saveProof(
 	if !common.IsProofsFlagEnabledForHeader(bp.enableEpochsHandler, header) {
 		return
 	}
+	// TODO: MX-17040: If we would send the processed header hash, this might work as previous usage:
+	// proof, err := bp.proofsPool.GetProof(header.GetShardID(), hash)
 
 	proof, err := bp.proofsPool.GetProofByNonce(header.GetNonce(), header.GetShardID())
 	if err != nil {

--- a/process/block/baseProcess.go
+++ b/process/block/baseProcess.go
@@ -529,10 +529,9 @@ func displayProofsExtraSignatures(
 func displayProofExtraSignatures(
 	lines []*display.LineData,
 	id string,
-	proofData data.ExtraSignatureDataHandler,
+	extraSigData data.ExtraSignatureDataHandler,
 ) []*display.LineData {
-	// TODO Check.ifNil here, add it to CORE
-	if proofData == nil {
+	if check.IfNil(extraSigData) {
 		return lines
 	}
 
@@ -544,12 +543,12 @@ func displayProofExtraSignatures(
 	lines = append(lines, display.NewLineData(false, []string{
 		"",
 		"Aggregated Signature",
-		logger.DisplayByteSlice(proofData.GetAggregatedSignature())}),
+		logger.DisplayByteSlice(extraSigData.GetAggregatedSignature())}),
 	)
 	lines = append(lines, display.NewLineData(false, []string{
 		"",
 		"Leader Signature",
-		logger.DisplayByteSlice(proofData.GetLeaderSignature())}),
+		logger.DisplayByteSlice(extraSigData.GetLeaderSignature())}),
 	)
 
 	lines[len(lines)-1].HorizontalRuleAfter = true

--- a/process/block/baseProcess.go
+++ b/process/block/baseProcess.go
@@ -503,14 +503,60 @@ func displayHeader(
 				"",
 				"Nonce",
 				fmt.Sprintf("%d", proofNonce)}),
-			display.NewLineData(true, []string{
-				"",
-				"IsStartOfEpoch",
-				fmt.Sprintf("%t", isStartOfEpoch)}),
+		)
+
+		logLines = displayProofsExtraSignatures(logLines, headerProof.GetExtraSignatureHandlers())
+
+		logLines = append(logLines, display.NewLineData(true, []string{
+			"",
+			"IsStartOfEpoch",
+			fmt.Sprintf("%t", isStartOfEpoch)}),
 		)
 	}
 
 	return logLines
+}
+
+func displayProofsExtraSignatures(
+	lines []*display.LineData,
+	proofExtraSignatures map[string]data.ExtraSignatureDataHandler,
+) []*display.LineData {
+	for id, proofData := range proofExtraSignatures {
+		lines = displayProofExtraSignatures(lines, id, proofData)
+	}
+
+	return lines
+}
+
+func displayProofExtraSignatures(
+	lines []*display.LineData,
+	id string,
+	proofData data.ExtraSignatureDataHandler,
+) []*display.LineData {
+	// TODO Check.ifNil here, add it to CORE
+	if proofData == nil {
+		return lines
+	}
+
+	lines = append(lines, display.NewLineData(false, []string{
+		"Extra signature",
+		"ID",
+		id}),
+	)
+	lines = append(lines, display.NewLineData(false, []string{
+		"",
+		"Aggregated Signature",
+		logger.DisplayByteSlice(proofData.GetAggregatedSignature())}),
+	)
+	lines = append(lines, display.NewLineData(false, []string{
+		"",
+		"Leader Signature",
+		logger.DisplayByteSlice(proofData.GetLeaderSignature())}),
+	)
+
+	lines[len(lines)-1].HorizontalRuleAfter = true
+
+	return lines
 }
 
 // checkProcessorParameters will check the input parameters values
@@ -1593,7 +1639,7 @@ func (bp *baseProcessor) saveProof(
 		return
 	}
 
-	proof, err := bp.proofsPool.GetProof(header.GetShardID(), hash)
+	proof, err := bp.proofsPool.GetProofByNonce(header.GetNonce(), header.GetShardID())
 	if err != nil {
 		log.Error("could not find proof for header",
 			"hash", hex.EncodeToString(hash),

--- a/process/block/baseProcess_test.go
+++ b/process/block/baseProcess_test.go
@@ -33,8 +33,8 @@ import (
 	"github.com/multiversx/mx-chain-go/config"
 	"github.com/multiversx/mx-chain-go/dataRetriever"
 	"github.com/multiversx/mx-chain-go/dataRetriever/blockchain"
-	errorsMx "github.com/multiversx/mx-chain-go/errors"
 	proofscache "github.com/multiversx/mx-chain-go/dataRetriever/dataPool/proofsCache"
+	errorsMx "github.com/multiversx/mx-chain-go/errors"
 	"github.com/multiversx/mx-chain-go/process"
 	blproc "github.com/multiversx/mx-chain-go/process/block"
 	"github.com/multiversx/mx-chain-go/process/block/bootstrapStorage"
@@ -3414,6 +3414,19 @@ func TestBaseProcessor_DisplayHeader(t *testing.T) {
 
 		lines := blproc.DisplayHeader(header, proof)
 		require.Equal(t, 23, len(lines))
+
+		proof.ExtraSignatures = map[string]*block.ExtraSignatureData{
+			block.OutGoingMbTx.String(): {
+				AggregatedSignature: []byte("aggSig1"),
+				LeaderSignature:     []byte("leaderSig1"),
+			},
+			block.OutGoingMbChangeValidatorSet.String(): {
+				AggregatedSignature: []byte("aggSig2"),
+				LeaderSignature:     []byte("leaderSig2"),
+			},
+		}
+		lines = blproc.DisplayHeader(header, proof)
+		require.Equal(t, 29, len(lines))
 	})
 	t.Run("meta header with proof info", func(t *testing.T) {
 		t.Parallel()

--- a/process/block/displayBlock.go
+++ b/process/block/displayBlock.go
@@ -138,7 +138,7 @@ func (txc *transactionCounter) displayLogInfo(
 	dataPool dataRetriever.PoolsHolder,
 	blockTracker process.BlockTracker,
 ) {
-	headerProof, _ := dataPool.Proofs().GetProof(selfId, headerHash)
+	headerProof, _ := dataPool.Proofs().GetProofByNonce(header.GetNonce(), header.GetShardID())
 	dispHeader, dispLines := txc.createDisplayableShardHeaderAndBlockBody(header, body, headerProof)
 
 	tblString, err := display.CreateTableString(dispHeader, dispLines)

--- a/process/block/displayBlock.go
+++ b/process/block/displayBlock.go
@@ -138,6 +138,9 @@ func (txc *transactionCounter) displayLogInfo(
 	dataPool dataRetriever.PoolsHolder,
 	blockTracker process.BlockTracker,
 ) {
+	// TODO: MX-17040: If we would send the processed header hash, this might work as previous usage:
+	// headerProof, _ := dataPool.Proofs().GetProof(selfId, headerHash)
+
 	headerProof, _ := dataPool.Proofs().GetProofByNonce(header.GetNonce(), header.GetShardID())
 	dispHeader, dispLines := txc.createDisplayableShardHeaderAndBlockBody(header, body, headerProof)
 

--- a/process/headerCheck/errors.go
+++ b/process/headerCheck/errors.go
@@ -25,3 +25,5 @@ var ErrProofHeaderHashMismatch = errors.New("proof header hash mismatch")
 
 // ErrProofNotExpected signals that the proof is not expected
 var ErrProofNotExpected = errors.New("proof not expected")
+
+var errNoExtraSignatureDataFoundInProof = errors.New("no extra signature data found in proof")

--- a/process/headerCheck/extraHeaderSigVerifierHolder.go
+++ b/process/headerCheck/extraHeaderSigVerifierHolder.go
@@ -25,20 +25,18 @@ func NewExtraHeaderSigVerifierHolder() *extraHeaderSigVerifierHolder {
 }
 
 // VerifyAggregatedSignature calls VerifyAggregatedSignature for all registered verifiers
-func (holder *extraHeaderSigVerifierHolder) VerifyAggregatedSignature(header data.HeaderHandler, multiSigVerifier crypto.MultiSigner, pubKeysSigners [][]byte) error {
+func (holder *extraHeaderSigVerifierHolder) VerifyAggregatedSignature(proof data.HeaderProofHandler, header data.HeaderHandler, multiSigVerifier crypto.MultiSigner, pubKeysSigners [][]byte) error {
 	holder.mutExtraVerifiers.RLock()
 	defer holder.mutExtraVerifiers.RUnlock()
 
 	for id, extraSigner := range holder.extraVerifiers {
-		err := extraSigner.VerifyAggregatedSignature(header, multiSigVerifier, pubKeysSigners)
+		err := extraSigner.VerifyAggregatedSignature(proof, header, multiSigVerifier, pubKeysSigners)
 		if err != nil {
 			log.Error("holder.VerifyAggregatedSignature",
 				"error", err.Error(),
 				"id", id,
 			)
-			// TODO: MX-17039 Restore these once we have extra sigs working
-			//return err
-			return nil
+			return err
 		}
 	}
 

--- a/process/headerCheck/extraHeaderSigVerifierHolder.go
+++ b/process/headerCheck/extraHeaderSigVerifierHolder.go
@@ -55,9 +55,7 @@ func (holder *extraHeaderSigVerifierHolder) VerifyLeaderSignature(header data.He
 				"error", err.Error(),
 				"id", id,
 			)
-			// TODO: MX-17039 Restore these once we have extra sigs working
-			// return err
-			return nil
+			return err
 		}
 	}
 

--- a/process/headerCheck/extraHeaderSigVerifierHolder_test.go
+++ b/process/headerCheck/extraHeaderSigVerifierHolder_test.go
@@ -6,11 +6,12 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-core-go/data/block"
 	crypto "github.com/multiversx/mx-chain-crypto-go"
+	"github.com/stretchr/testify/require"
+
 	"github.com/multiversx/mx-chain-go/consensus/mock"
 	"github.com/multiversx/mx-chain-go/errors"
 	"github.com/multiversx/mx-chain-go/testscommon/cryptoMocks"
 	"github.com/multiversx/mx-chain-go/testscommon/headerSigVerifier"
-	"github.com/stretchr/testify/require"
 )
 
 func TestExtraHeaderSigVerifierHolder_VerifyAggregatedSignature(t *testing.T) {
@@ -24,7 +25,7 @@ func TestExtraHeaderSigVerifierHolder_VerifyAggregatedSignature(t *testing.T) {
 	expectedPubKeys := [][]byte{[]byte("pk1"), []byte("pk2")}
 
 	extraVerifier1 := &headerSigVerifier.ExtraHeaderSigVerifierHandlerMock{
-		VerifyAggregatedSignatureCalled: func(header data.HeaderHandler, multiSigVerifier crypto.MultiSigner, pubKeysSigners [][]byte) error {
+		VerifyAggregatedSignatureCalled: func(proof data.HeaderProofHandler, header data.HeaderHandler, multiSigVerifier crypto.MultiSigner, pubKeysSigners [][]byte) error {
 			require.Equal(t, expectedHdr, header)
 			require.Equal(t, expectedVerifier, multiSigVerifier)
 			require.Equal(t, expectedPubKeys, pubKeysSigners)
@@ -37,7 +38,7 @@ func TestExtraHeaderSigVerifierHolder_VerifyAggregatedSignature(t *testing.T) {
 		},
 	}
 	extraVerifier2 := &headerSigVerifier.ExtraHeaderSigVerifierHandlerMock{
-		VerifyAggregatedSignatureCalled: func(header data.HeaderHandler, multiSigVerifier crypto.MultiSigner, pubKeysSigners [][]byte) error {
+		VerifyAggregatedSignatureCalled: func(proof data.HeaderProofHandler, header data.HeaderHandler, multiSigVerifier crypto.MultiSigner, pubKeysSigners [][]byte) error {
 			require.Equal(t, expectedHdr, header)
 			require.Equal(t, expectedVerifier, multiSigVerifier)
 			require.Equal(t, expectedPubKeys, pubKeysSigners)
@@ -60,7 +61,7 @@ func TestExtraHeaderSigVerifierHolder_VerifyAggregatedSignature(t *testing.T) {
 	err = holder.RegisterExtraHeaderSigVerifier(extraVerifier1)
 	require.Equal(t, errors.ErrExtraSignerIdAlreadyExists, err)
 
-	err = holder.VerifyAggregatedSignature(expectedHdr, expectedVerifier, expectedPubKeys)
+	err = holder.VerifyAggregatedSignature(nil, expectedHdr, expectedVerifier, expectedPubKeys)
 	require.Nil(t, err)
 	require.True(t, wasVerifyCalled1)
 	require.True(t, wasVerifyCalled2)

--- a/process/headerCheck/headerSignatureVerify.go
+++ b/process/headerCheck/headerSignatureVerify.go
@@ -333,7 +333,12 @@ func (hsv *HeaderSigVerifier) getHeaderForProofAtTransition(proof data.HeaderPro
 }
 
 func (hsv *HeaderSigVerifier) getHeaderForProof(proof data.HeaderProofHandler) (data.HeaderHandler, error) {
-	hdr, _, err := process.GetShardHeaderWithNonce(
+	hdr, err := process.GetHeader(proof.GetHeaderHash(), hsv.headersPool, hsv.storageService, hsv.marshalizer, proof.GetHeaderShardId())
+	if err == nil {
+		return hdr, nil
+	}
+
+	hdr, _, err = process.GetShardHeaderWithNonce(
 		proof.GetHeaderNonce(),
 		proof.GetHeaderShardId(),
 		hsv.headersPool,

--- a/process/headerCheck/headerSignatureVerify.go
+++ b/process/headerCheck/headerSignatureVerify.go
@@ -314,6 +314,8 @@ func (hsv *HeaderSigVerifier) getHeaderForProofAtTransition(proof data.HeaderPro
 	var err error
 
 	for {
+		// TODO: MX-17040: If we would send the processed header hash, this might work as previous usage
+		// header, err = process.GetHeader(proof.GetHeaderHash(), hsv.headersPool, hsv.storageService, hsv.marshalizer, proof.GetHeaderShardId())
 		header, err = hsv.getHeaderForProof(proof)
 		if err == nil {
 			break
@@ -337,6 +339,7 @@ func (hsv *HeaderSigVerifier) getHeaderForProof(proof data.HeaderProofHandler) (
 		hsv.headersPool,
 		hsv.marshalizer,
 		hsv.storageService,
+		// TODO: MX-17040: This shall be either injected from constructor, or totally replaced if we use processed header hash
 		uint64ByteSlice.NewBigEndianConverter(),
 	)
 	return hdr, err

--- a/process/headerCheck/headerSignatureVerify.go
+++ b/process/headerCheck/headerSignatureVerify.go
@@ -7,6 +7,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/core/check"
 	"github.com/multiversx/mx-chain-core-go/data"
+	"github.com/multiversx/mx-chain-core-go/data/typeConverters/uint64ByteSlice"
 	"github.com/multiversx/mx-chain-core-go/hashing"
 	"github.com/multiversx/mx-chain-core-go/marshal"
 	crypto "github.com/multiversx/mx-chain-crypto-go"
@@ -306,7 +307,7 @@ func (hsv *HeaderSigVerifier) VerifySignatureForHash(header data.HeaderHandler, 
 		return err
 	}
 
-	return hsv.extraSigVerifierHolder.VerifyAggregatedSignature(header, multiSigVerifier, pubKeysSigners)
+	return hsv.extraSigVerifierHolder.VerifyAggregatedSignature(nil, header, multiSigVerifier, pubKeysSigners)
 }
 
 func (hsv *HeaderSigVerifier) getHeaderForProofAtTransition(proof data.HeaderProofHandler) (data.HeaderHandler, error) {
@@ -314,7 +315,7 @@ func (hsv *HeaderSigVerifier) getHeaderForProofAtTransition(proof data.HeaderPro
 	var err error
 
 	for {
-		header, err = process.GetHeader(proof.GetHeaderHash(), hsv.headersPool, hsv.storageService, hsv.marshalizer, proof.GetHeaderShardId())
+		header, err = hsv.getHeaderForProof(proof)
 		if err == nil {
 			break
 		}
@@ -328,6 +329,18 @@ func (hsv *HeaderSigVerifier) getHeaderForProofAtTransition(proof data.HeaderPro
 	}
 
 	return header, nil
+}
+
+func (hsv *HeaderSigVerifier) getHeaderForProof(proof data.HeaderProofHandler) (data.HeaderHandler, error) {
+	hdr, _, err := process.GetShardHeaderWithNonce(
+		proof.GetHeaderNonce(),
+		proof.GetHeaderShardId(),
+		hsv.headersPool,
+		hsv.marshalizer,
+		hsv.storageService,
+		uint64ByteSlice.NewBigEndianConverter(),
+	)
+	return hdr, err
 }
 
 func (hsv *HeaderSigVerifier) verifyHeaderProofAtTransition(proof data.HeaderProofHandler) error {
@@ -356,7 +369,12 @@ func (hsv *HeaderSigVerifier) verifyHeaderProofAtTransition(proof data.HeaderPro
 		return err
 	}
 
-	return multiSigVerifier.VerifyAggregatedSig(consensusPubKeys, proof.GetHeaderHash(), proof.GetAggregatedSignature())
+	err = multiSigVerifier.VerifyAggregatedSig(consensusPubKeys, proof.GetHeaderHash(), proof.GetAggregatedSignature())
+	if err != nil {
+		return err
+	}
+
+	return hsv.extraSigVerifierHolder.VerifyAggregatedSignature(proof, header, multiSigVerifier, consensusPubKeys)
 }
 
 // TODO: MX-17039- verify extra signers
@@ -384,7 +402,17 @@ func (hsv *HeaderSigVerifier) VerifyHeaderProof(proofHandler data.HeaderProofHan
 		return err
 	}
 
-	return multiSigVerifier.VerifyAggregatedSig(consensusPubKeys, proofHandler.GetHeaderHash(), proofHandler.GetAggregatedSignature())
+	err = multiSigVerifier.VerifyAggregatedSig(consensusPubKeys, proofHandler.GetHeaderHash(), proofHandler.GetAggregatedSignature())
+	if err != nil {
+		return err
+	}
+
+	header, err := hsv.getHeaderForProof(proofHandler)
+	if err != nil {
+		return err
+	}
+
+	return hsv.extraSigVerifierHolder.VerifyAggregatedSignature(proofHandler, header, multiSigVerifier, consensusPubKeys)
 }
 
 // VerifyRandSeed will check if rand seed is correct

--- a/process/headerCheck/headerSignatureVerify.go
+++ b/process/headerCheck/headerSignatureVerify.go
@@ -257,7 +257,6 @@ func getPubKeySigners(consensusPubKeys []string, pubKeysBitmap []byte) [][]byte 
 
 // VerifySignature will check if signature is correct
 func (hsv *HeaderSigVerifier) VerifySignature(header data.HeaderHandler) error {
-	// TODO: MARIUS C: MX-17039 This is not ok for sovereign, we still need to check signatures for outgoing ops
 	if hsv.enableEpochsHandler.IsFlagEnabledInEpoch(common.AndromedaFlag, header.GetEpoch()) {
 		return nil
 	}
@@ -376,8 +375,6 @@ func (hsv *HeaderSigVerifier) verifyHeaderProofAtTransition(proof data.HeaderPro
 
 	return hsv.extraSigVerifierHolder.VerifyAggregatedSignature(proof, header, multiSigVerifier, consensusPubKeys)
 }
-
-// TODO: MX-17039- verify extra signers
 
 // VerifyHeaderProof checks if the proof is correct for the header
 func (hsv *HeaderSigVerifier) VerifyHeaderProof(proofHandler data.HeaderProofHandler) error {

--- a/process/headerCheck/headerSignatureVerify_test.go
+++ b/process/headerCheck/headerSignatureVerify_test.go
@@ -717,7 +717,7 @@ func TestHeaderSigVerifier_VerifySignatureOk(t *testing.T) {
 		}})
 
 	args.ExtraHeaderSigVerifierHolder = &headerSigVerifier.ExtraHeaderSigVerifierHolderMock{
-		VerifyAggregatedSignatureCalled: func(header data.HeaderHandler, multiSigVerifier crypto.MultiSigner, pubKeysSigners [][]byte) error {
+		VerifyAggregatedSignatureCalled: func(proof data.HeaderProofHandler, header data.HeaderHandler, multiSigVerifier crypto.MultiSigner, pubKeysSigners [][]byte) error {
 			wasExtraHdrSigVerifierCalled = true
 			return nil
 		},

--- a/process/headerCheck/interface.go
+++ b/process/headerCheck/interface.go
@@ -3,12 +3,13 @@ package headerCheck
 import (
 	"github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-crypto-go"
+
 	"github.com/multiversx/mx-chain-go/process"
 )
 
 // ExtraHeaderSigVerifierHolder manages extra header verifiers
 type ExtraHeaderSigVerifierHolder interface {
-	VerifyAggregatedSignature(header data.HeaderHandler, multiSigVerifier crypto.MultiSigner, pubKeysSigners [][]byte) error
+	VerifyAggregatedSignature(proof data.HeaderProofHandler, header data.HeaderHandler, multiSigVerifier crypto.MultiSigner, pubKeysSigners [][]byte) error
 	VerifyLeaderSignature(header data.HeaderHandler, leaderPubKey crypto.PublicKey) error
 	RemoveLeaderSignature(header data.HeaderHandler) error
 	RemoveAllSignatures(header data.HeaderHandler) error

--- a/process/headerCheck/sovereignHeaderSignatureVerifier.go
+++ b/process/headerCheck/sovereignHeaderSignatureVerifier.go
@@ -5,29 +5,40 @@ import (
 
 	"github.com/multiversx/mx-chain-core-go/core/check"
 	"github.com/multiversx/mx-chain-core-go/data"
+	"github.com/multiversx/mx-chain-core-go/data/block"
 	crypto "github.com/multiversx/mx-chain-crypto-go"
 
+	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/errors"
 	"github.com/multiversx/mx-chain-go/process"
 )
 
 type sovereignHeaderSigVerifier struct {
-	singleSigVerifier crypto.SingleSigner
+	singleSigVerifier   crypto.SingleSigner
+	enableEpochsHandler common.EnableEpochsHandler
 }
 
 // NewSovereignHeaderSigVerifier creates a new sovereign header sig verifier for outgoing operations
-func NewSovereignHeaderSigVerifier(singleSigVerifier crypto.SingleSigner) (*sovereignHeaderSigVerifier, error) {
+func NewSovereignHeaderSigVerifier(
+	singleSigVerifier crypto.SingleSigner,
+	enableEpochsHandler common.EnableEpochsHandler,
+) (*sovereignHeaderSigVerifier, error) {
 	if check.IfNil(singleSigVerifier) {
 		return nil, process.ErrNilSingleSigner
 	}
+	if check.IfNil(enableEpochsHandler) {
+		return nil, errors.ErrNilEnableEpochsHandler
+	}
 
 	return &sovereignHeaderSigVerifier{
-		singleSigVerifier: singleSigVerifier,
+		singleSigVerifier:   singleSigVerifier,
+		enableEpochsHandler: enableEpochsHandler,
 	}, nil
 }
 
 // VerifyAggregatedSignature verifies aggregated sig for outgoing operations
 func (hsv *sovereignHeaderSigVerifier) VerifyAggregatedSignature(
+	proof data.HeaderProofHandler,
 	header data.HeaderHandler,
 	multiSigVerifier crypto.MultiSigner,
 	pubKeysSigners [][]byte,
@@ -38,10 +49,26 @@ func (hsv *sovereignHeaderSigVerifier) VerifyAggregatedSignature(
 	}
 
 	for _, outGoingMBHdr := range sovHeader.GetOutGoingMiniBlockHeaderHandlers() {
+		aggregatedSig := outGoingMBHdr.GetAggregatedSignatureOutGoingOperations()
+
+		if hsv.enableEpochsHandler.IsFlagEnabled(common.AndromedaFlag) {
+			if check.IfNil(proof) {
+				return process.ErrNilHeaderProof
+			}
+
+			extraSigHandler, found := proof.GetExtraSignatureHandlers()[block.OutGoingMBType(outGoingMBHdr.GetOutGoingMBTypeInt32()).String()]
+			if !found {
+				return fmt.Errorf("%w in sovereignHeaderSigVerifier.VerifyAggregatedSignature for header hash: %x, round: %d",
+					errNoExtraSignatureDataFoundInProof, proof.GetHeaderHash(), proof.GetHeaderRound())
+			}
+
+			aggregatedSig = extraSigHandler.GetAggregatedSignature()
+		}
+
 		err := multiSigVerifier.VerifyAggregatedSig(
 			pubKeysSigners,
 			outGoingMBHdr.GetOutGoingOperationsHash(),
-			outGoingMBHdr.GetAggregatedSignatureOutGoingOperations(),
+			aggregatedSig,
 		)
 		if err != nil {
 			return err

--- a/process/headerCheck/sovereignHeaderSignatureVerifier.go
+++ b/process/headerCheck/sovereignHeaderSignatureVerifier.go
@@ -49,23 +49,12 @@ func (hsv *sovereignHeaderSigVerifier) VerifyAggregatedSignature(
 	}
 
 	for _, outGoingMBHdr := range sovHeader.GetOutGoingMiniBlockHeaderHandlers() {
-		aggregatedSig := outGoingMBHdr.GetAggregatedSignatureOutGoingOperations()
-
-		if hsv.enableEpochsHandler.IsFlagEnabled(common.AndromedaFlag) {
-			if check.IfNil(proof) {
-				return process.ErrNilHeaderProof
-			}
-
-			extraSigHandler, found := proof.GetExtraSignatureHandlers()[block.OutGoingMBType(outGoingMBHdr.GetOutGoingMBTypeInt32()).String()]
-			if !found {
-				return fmt.Errorf("%w in sovereignHeaderSigVerifier.VerifyAggregatedSignature for header hash: %x, round: %d",
-					errNoExtraSignatureDataFoundInProof, proof.GetHeaderHash(), proof.GetHeaderRound())
-			}
-
-			aggregatedSig = extraSigHandler.GetAggregatedSignature()
+		aggregatedSig, err := hsv.getAggregatedSignature(outGoingMBHdr, proof)
+		if err != nil {
+			return err
 		}
 
-		err := multiSigVerifier.VerifyAggregatedSig(
+		err = multiSigVerifier.VerifyAggregatedSig(
 			pubKeysSigners,
 			outGoingMBHdr.GetOutGoingOperationsHash(),
 			aggregatedSig,
@@ -76,6 +65,28 @@ func (hsv *sovereignHeaderSigVerifier) VerifyAggregatedSignature(
 	}
 
 	return nil
+}
+
+func (hsv *sovereignHeaderSigVerifier) getAggregatedSignature(
+	outGoingMBHdr data.OutGoingMiniBlockHeaderHandler,
+	proof data.HeaderProofHandler,
+) ([]byte, error) {
+	if !hsv.enableEpochsHandler.IsFlagEnabled(common.AndromedaFlag) {
+		return outGoingMBHdr.GetAggregatedSignatureOutGoingOperations(), nil
+	}
+
+	if check.IfNil(proof) {
+		return nil, process.ErrNilHeaderProof
+	}
+
+	mbTypeStr := block.OutGoingMBType(outGoingMBHdr.GetOutGoingMBTypeInt32()).String()
+	extraSigHandler, found := proof.GetExtraSignatureHandlers()[mbTypeStr]
+	if !found {
+		return nil, fmt.Errorf("%w in sovereignHeaderSigVerifier.VerifyAggregatedSignature for header hash: %x, round: %d",
+			errNoExtraSignatureDataFoundInProof, proof.GetHeaderHash(), proof.GetHeaderRound())
+	}
+
+	return extraSigHandler.GetAggregatedSignature(), nil
 }
 
 // VerifyLeaderSignature verifies leader sig for outgoing operations
@@ -89,16 +100,9 @@ func (hsv *sovereignHeaderSigVerifier) VerifyLeaderSignature(
 	}
 
 	for _, outGoingMBHdr := range sovHeader.GetOutGoingMiniBlockHeaderHandlers() {
-		leaderMsgToSign := outGoingMBHdr.GetOutGoingOperationsHash()
-
-		// In consensus v2 leader will only sign the outgoing op hash
-		if !hsv.enableEpochsHandler.IsFlagEnabled(common.AndromedaFlag) {
-			leaderMsgToSign = append(leaderMsgToSign, outGoingMBHdr.GetAggregatedSignatureOutGoingOperations()...)
-		}
-
 		err := hsv.singleSigVerifier.Verify(
 			leaderPubKey,
-			leaderMsgToSign,
+			hsv.getLeaderSignedMessage(outGoingMBHdr),
 			outGoingMBHdr.GetLeaderSignatureOutGoingOperations())
 		if err != nil {
 			return err
@@ -106,6 +110,15 @@ func (hsv *sovereignHeaderSigVerifier) VerifyLeaderSignature(
 	}
 
 	return nil
+}
+
+func (hsv *sovereignHeaderSigVerifier) getLeaderSignedMessage(outGoingMBHdr data.OutGoingMiniBlockHeaderHandler) []byte {
+	// In consensus v2 leader will only sign the outgoing op hash
+	if hsv.enableEpochsHandler.IsFlagEnabled(common.AndromedaFlag) {
+		return outGoingMBHdr.GetOutGoingOperationsHash()
+	}
+
+	return append(outGoingMBHdr.GetOutGoingOperationsHash(), outGoingMBHdr.GetAggregatedSignatureOutGoingOperations()...)
 }
 
 // RemoveLeaderSignature removes leader sig from outgoing operations

--- a/process/headerCheck/sovereignHeaderSignatureVerifier.go
+++ b/process/headerCheck/sovereignHeaderSignatureVerifier.go
@@ -89,9 +89,12 @@ func (hsv *sovereignHeaderSigVerifier) VerifyLeaderSignature(
 	}
 
 	for _, outGoingMBHdr := range sovHeader.GetOutGoingMiniBlockHeaderHandlers() {
-		leaderMsgToSign := append(
-			outGoingMBHdr.GetOutGoingOperationsHash(),
-			outGoingMBHdr.GetAggregatedSignatureOutGoingOperations()...)
+		leaderMsgToSign := outGoingMBHdr.GetOutGoingOperationsHash()
+
+		// In consensus v2 leader will only sign the outgoing op hash
+		if !hsv.enableEpochsHandler.IsFlagEnabled(common.AndromedaFlag) {
+			leaderMsgToSign = append(leaderMsgToSign, outGoingMBHdr.GetAggregatedSignatureOutGoingOperations()...)
+		}
 
 		err := hsv.singleSigVerifier.Verify(
 			leaderPubKey,

--- a/process/headerCheck/sovereignHeaderSignatureVerifier_test.go
+++ b/process/headerCheck/sovereignHeaderSignatureVerifier_test.go
@@ -3,6 +3,7 @@ package headerCheck
 import (
 	"testing"
 
+	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/core/check"
 	"github.com/multiversx/mx-chain-core-go/data/block"
 	crypto "github.com/multiversx/mx-chain-crypto-go"
@@ -13,19 +14,20 @@ import (
 	"github.com/multiversx/mx-chain-go/process"
 	"github.com/multiversx/mx-chain-go/process/mock"
 	"github.com/multiversx/mx-chain-go/testscommon/cryptoMocks"
+	"github.com/multiversx/mx-chain-go/testscommon/enableEpochsHandlerMock"
 )
 
 func TestNewSovereignHeaderSigVerifier(t *testing.T) {
 	t.Parallel()
 
 	t.Run("nil verifier, should return error", func(t *testing.T) {
-		sovVerifier, err := NewSovereignHeaderSigVerifier(nil)
+		sovVerifier, err := NewSovereignHeaderSigVerifier(nil, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
 		require.Equal(t, process.ErrNilSingleSigner, err)
 		require.Nil(t, sovVerifier)
 	})
 
 	t.Run("should work", func(t *testing.T) {
-		sovVerifier, err := NewSovereignHeaderSigVerifier(&mock.SignerMock{})
+		sovVerifier, err := NewSovereignHeaderSigVerifier(&mock.SignerMock{}, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
 		require.Nil(t, err)
 		require.False(t, check.IfNil(sovVerifier))
 		require.Equal(t, "sovereignHeaderSigVerifier", sovVerifier.Identifier())
@@ -61,25 +63,121 @@ func TestSovereignHeaderSigVerifier_VerifyAggregatedSignature(t *testing.T) {
 			return nil
 		},
 	}
-	sovVerifier, _ := NewSovereignHeaderSigVerifier(&mock.SignerMock{})
+	sovVerifier, _ := NewSovereignHeaderSigVerifier(&mock.SignerMock{}, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
 
 	t.Run("invalid header type, should return error", func(t *testing.T) {
-		err := sovVerifier.VerifyAggregatedSignature(sovHdr.Header, multiSigner, expectedPubKeys)
+		err := sovVerifier.VerifyAggregatedSignature(nil, sovHdr.Header, multiSigner, expectedPubKeys)
 		require.ErrorIs(t, err, errors.ErrWrongTypeAssertion)
 	})
 
 	t.Run("no outgoing mini block header", func(t *testing.T) {
 		sovHdrCopy := *sovHdr
 		sovHdrCopy.OutGoingMiniBlockHeaders = nil
-		err := sovVerifier.VerifyAggregatedSignature(&sovHdrCopy, multiSigner, expectedPubKeys)
+		err := sovVerifier.VerifyAggregatedSignature(nil, &sovHdrCopy, multiSigner, expectedPubKeys)
 		require.Nil(t, err)
 		require.Zero(t, verifyCalledCt)
 	})
 
 	t.Run("should create sig share", func(t *testing.T) {
-		err := sovVerifier.VerifyAggregatedSignature(sovHdr, multiSigner, expectedPubKeys)
+		err := sovVerifier.VerifyAggregatedSignature(nil, sovHdr, multiSigner, expectedPubKeys)
 		require.Nil(t, err)
 		require.Equal(t, 1, verifyCalledCt)
+	})
+}
+
+func TestSovereignHeaderSigVerifier_getAggregatedSignature(t *testing.T) {
+	t.Parallel()
+
+	isAndromedaActive := false
+	enableEpochsHandler := &enableEpochsHandlerMock.EnableEpochsHandlerStub{
+		IsFlagEnabledCalled: func(flag core.EnableEpochFlag) bool {
+			return isAndromedaActive
+		},
+	}
+	sovVerifier, _ := NewSovereignHeaderSigVerifier(&mock.SignerMock{}, enableEpochsHandler)
+
+	outGoingOpHash := []byte("outGoingOpHash")
+	outGoingAggregatedSig := []byte("aggregatedSig")
+	outGoingMBHeader := &block.OutGoingMiniBlockHeader{
+		Type:                                  block.OutGoingMbTx,
+		OutGoingOperationsHash:                outGoingOpHash,
+		AggregatedSignatureOutGoingOperations: outGoingAggregatedSig,
+	}
+
+	t.Run("andromeda not active", func(t *testing.T) {
+		aggSig, err := sovVerifier.getAggregatedSignature(outGoingMBHeader, nil)
+		require.Nil(t, err)
+		require.Equal(t, outGoingAggregatedSig, aggSig)
+	})
+
+	isAndromedaActive = true
+
+	t.Run("andromeda active, nil proof", func(t *testing.T) {
+		aggSig, err := sovVerifier.getAggregatedSignature(outGoingMBHeader, nil)
+		require.Nil(t, aggSig)
+		require.Equal(t, process.ErrNilHeaderProof, err)
+	})
+
+	t.Run("andromeda active, extra sig data not found for specific outgoing mb header", func(t *testing.T) {
+		proof := &block.HeaderProof{
+			ExtraSignatures: map[string]*block.ExtraSignatureData{
+				block.OutGoingMbChangeValidatorSet.String(): {
+					AggregatedSignature: outGoingAggregatedSig,
+				},
+			},
+		}
+		aggSig, err := sovVerifier.getAggregatedSignature(outGoingMBHeader, proof)
+		require.Nil(t, aggSig)
+		require.ErrorIs(t, err, errNoExtraSignatureDataFoundInProof)
+	})
+
+	t.Run("should work with andromeda", func(t *testing.T) {
+		aggregatedSigFromProof := []byte("aggregatedSigFromProof")
+		proof := &block.HeaderProof{
+			ExtraSignatures: map[string]*block.ExtraSignatureData{
+				block.OutGoingMbTx.String(): {
+					AggregatedSignature: aggregatedSigFromProof,
+				},
+			},
+		}
+		aggSig, err := sovVerifier.getAggregatedSignature(outGoingMBHeader, proof)
+		require.Nil(t, err)
+		require.Equal(t, aggregatedSigFromProof, aggSig)
+	})
+
+}
+
+func TestSovereignHeaderSigVerifier_getLeaderSignedMessage(t *testing.T) {
+	t.Parallel()
+
+	isAndromedaActive := false
+	enableEpochsHandler := &enableEpochsHandlerMock.EnableEpochsHandlerStub{
+		IsFlagEnabledCalled: func(flag core.EnableEpochFlag) bool {
+			return isAndromedaActive
+		},
+	}
+	sovVerifier, _ := NewSovereignHeaderSigVerifier(&mock.SignerMock{}, enableEpochsHandler)
+
+	outGoingOpHash := []byte("outGoingOpHash")
+	outGoingAggregatedSig := []byte("aggregatedSig")
+	outGoingMBHeader := &block.OutGoingMiniBlockHeader{
+		Type:                                  block.OutGoingMbTx,
+		OutGoingOperationsHash:                outGoingOpHash,
+		AggregatedSignatureOutGoingOperations: outGoingAggregatedSig,
+	}
+
+	t.Run("before andromeda", func(t *testing.T) {
+		signedMsg := sovVerifier.getLeaderSignedMessage(outGoingMBHeader)
+		require.Equal(t, append(
+			outGoingMBHeader.GetOutGoingOperationsHash(),
+			outGoingMBHeader.GetAggregatedSignatureOutGoingOperations()...),
+			signedMsg)
+	})
+
+	t.Run("after andromeda", func(t *testing.T) {
+		isAndromedaActive = true
+		signedMsg := sovVerifier.getLeaderSignedMessage(outGoingMBHeader)
+		require.Equal(t, outGoingMBHeader.GetOutGoingOperationsHash(), signedMsg)
 	})
 }
 
@@ -114,7 +212,7 @@ func TestSovereignHeaderSigVerifier_VerifyLeaderSignature(t *testing.T) {
 			return nil
 		},
 	}
-	sovVerifier, _ := NewSovereignHeaderSigVerifier(signingHandler)
+	sovVerifier, _ := NewSovereignHeaderSigVerifier(signingHandler, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
 
 	t.Run("invalid header type, should return error", func(t *testing.T) {
 		err := sovVerifier.VerifyLeaderSignature(sovHdr.Header, expectedLeaderPubKey)
@@ -155,7 +253,7 @@ func TestSovereignHeaderSigVerifier_RemoveLeaderSignature(t *testing.T) {
 		},
 	}
 
-	sovVerifier, _ := NewSovereignHeaderSigVerifier(&mock.SignerMock{})
+	sovVerifier, _ := NewSovereignHeaderSigVerifier(&mock.SignerMock{}, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
 
 	t.Run("invalid header type, should return error", func(t *testing.T) {
 		err := sovVerifier.RemoveLeaderSignature(sovHdr.Header)
@@ -206,7 +304,7 @@ func TestSovereignHeaderSigVerifier_RemoveAllSignatures(t *testing.T) {
 		},
 	}
 
-	sovVerifier, _ := NewSovereignHeaderSigVerifier(&mock.SignerMock{})
+	sovVerifier, _ := NewSovereignHeaderSigVerifier(&mock.SignerMock{}, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
 
 	t.Run("invalid header type, should return error", func(t *testing.T) {
 		err := sovVerifier.RemoveAllSignatures(sovHdr.Header)

--- a/process/interface.go
+++ b/process/interface.go
@@ -1489,7 +1489,7 @@ type IncomingHeaderSubscriber interface {
 
 // ExtraHeaderSigVerifierHandler defines the required properties of an extra header sig verifier for additional data
 type ExtraHeaderSigVerifierHandler interface {
-	VerifyAggregatedSignature(header data.HeaderHandler, multiSigVerifier crypto.MultiSigner, pubKeysSigners [][]byte) error
+	VerifyAggregatedSignature(proof data.HeaderProofHandler, header data.HeaderHandler, multiSigVerifier crypto.MultiSigner, pubKeysSigners [][]byte) error
 	VerifyLeaderSignature(header data.HeaderHandler, leaderPubKey crypto.PublicKey) error
 	RemoveLeaderSignature(header data.HeaderHandler) error
 	RemoveAllSignatures(header data.HeaderHandler) error

--- a/testscommon/consensus/sposWorkerMock.go
+++ b/testscommon/consensus/sposWorkerMock.go
@@ -36,6 +36,7 @@ type SposWorkerMock struct {
 	ReceivedProofCalled                    func(proofHandler consensus.ProofHandler)
 	ResetConsensusRoundStateCalled         func()
 	ResetInvalidSignersCacheCalled         func()
+	ResetReceivedProofHandlerCalled        func()
 }
 
 // ResetConsensusRoundState -
@@ -74,9 +75,17 @@ func (sposWorkerMock *SposWorkerMock) RemoveAllReceivedHeaderHandlers() {
 	}
 }
 
+// AddReceivedProofHandler -
 func (sposWorkerMock *SposWorkerMock) AddReceivedProofHandler(handler func(proofHandler consensus.ProofHandler)) {
 	if sposWorkerMock.AddReceivedProofHandlerCalled != nil {
 		sposWorkerMock.AddReceivedProofHandlerCalled(handler)
+	}
+}
+
+// ResetReceivedProofHandler -
+func (sposWorkerMock *SposWorkerMock) ResetReceivedProofHandler() {
+	if sposWorkerMock.ResetReceivedProofHandlerCalled != nil {
+		sposWorkerMock.ResetReceivedProofHandlerCalled()
 	}
 }
 

--- a/testscommon/headerSigVerifier/extraHeaderSigVerifierHandlerMock.go
+++ b/testscommon/headerSigVerifier/extraHeaderSigVerifierHandlerMock.go
@@ -7,7 +7,7 @@ import (
 
 // ExtraHeaderSigVerifierHandlerMock -
 type ExtraHeaderSigVerifierHandlerMock struct {
-	VerifyAggregatedSignatureCalled func(header data.HeaderHandler, multiSigVerifier crypto.MultiSigner, pubKeysSigners [][]byte) error
+	VerifyAggregatedSignatureCalled func(proof data.HeaderProofHandler, header data.HeaderHandler, multiSigVerifier crypto.MultiSigner, pubKeysSigners [][]byte) error
 	VerifyLeaderSignatureCalled     func(header data.HeaderHandler, leaderPubKey crypto.PublicKey) error
 	RemoveLeaderSignatureCalled     func(header data.HeaderHandler) error
 	RemoveAllSignaturesCalled       func(header data.HeaderHandler) error
@@ -15,9 +15,9 @@ type ExtraHeaderSigVerifierHandlerMock struct {
 }
 
 // VerifyAggregatedSignature -
-func (mock *ExtraHeaderSigVerifierHandlerMock) VerifyAggregatedSignature(header data.HeaderHandler, multiSigVerifier crypto.MultiSigner, pubKeysSigners [][]byte) error {
+func (mock *ExtraHeaderSigVerifierHandlerMock) VerifyAggregatedSignature(proof data.HeaderProofHandler, header data.HeaderHandler, multiSigVerifier crypto.MultiSigner, pubKeysSigners [][]byte) error {
 	if mock.VerifyAggregatedSignatureCalled != nil {
-		return mock.VerifyAggregatedSignatureCalled(header, multiSigVerifier, pubKeysSigners)
+		return mock.VerifyAggregatedSignatureCalled(proof, header, multiSigVerifier, pubKeysSigners)
 	}
 	return nil
 }

--- a/testscommon/headerSigVerifier/extraHeaderSigVerifierHolderMock.go
+++ b/testscommon/headerSigVerifier/extraHeaderSigVerifierHolderMock.go
@@ -3,12 +3,13 @@ package headerSigVerifier
 import (
 	"github.com/multiversx/mx-chain-core-go/data"
 	crypto "github.com/multiversx/mx-chain-crypto-go"
+
 	"github.com/multiversx/mx-chain-go/process"
 )
 
 // ExtraHeaderSigVerifierHolderMock -
 type ExtraHeaderSigVerifierHolderMock struct {
-	VerifyAggregatedSignatureCalled      func(header data.HeaderHandler, multiSigVerifier crypto.MultiSigner, pubKeysSigners [][]byte) error
+	VerifyAggregatedSignatureCalled      func(proof data.HeaderProofHandler, header data.HeaderHandler, multiSigVerifier crypto.MultiSigner, pubKeysSigners [][]byte) error
 	VerifyLeaderSignatureCalled          func(header data.HeaderHandler, leaderPubKey crypto.PublicKey) error
 	RemoveLeaderSignatureCalled          func(header data.HeaderHandler) error
 	RemoveAllSignaturesCalled            func(header data.HeaderHandler) error
@@ -16,9 +17,9 @@ type ExtraHeaderSigVerifierHolderMock struct {
 }
 
 // VerifyAggregatedSignature -
-func (mock *ExtraHeaderSigVerifierHolderMock) VerifyAggregatedSignature(header data.HeaderHandler, multiSigVerifier crypto.MultiSigner, pubKeysSigners [][]byte) error {
+func (mock *ExtraHeaderSigVerifierHolderMock) VerifyAggregatedSignature(proof data.HeaderProofHandler, header data.HeaderHandler, multiSigVerifier crypto.MultiSigner, pubKeysSigners [][]byte) error {
 	if mock.VerifyAggregatedSignatureCalled != nil {
-		return mock.VerifyAggregatedSignatureCalled(header, multiSigVerifier, pubKeysSigners)
+		return mock.VerifyAggregatedSignatureCalled(proof, header, multiSigVerifier, pubKeysSigners)
 	}
 	return nil
 }

--- a/testscommon/processMocks/headerProofHandlerStub.go
+++ b/testscommon/processMocks/headerProofHandlerStub.go
@@ -17,6 +17,7 @@ type HeaderProofHandlerStub struct {
 	GetExtraSignatureHandlersCalled func() map[string]data.ExtraSignatureDataHandler
 }
 
+// GetExtraSignatureHandlers -
 func (h *HeaderProofHandlerStub) GetExtraSignatureHandlers() map[string]data.ExtraSignatureDataHandler {
 	if h.GetExtraSignatureHandlersCalled != nil {
 		return h.GetExtraSignatureHandlersCalled()

--- a/testscommon/processMocks/headerProofHandlerStub.go
+++ b/testscommon/processMocks/headerProofHandlerStub.go
@@ -1,15 +1,28 @@
 package processMocks
 
+import (
+	"github.com/multiversx/mx-chain-core-go/data"
+)
+
 // HeaderProofHandlerStub -
 type HeaderProofHandlerStub struct {
-	GetPubKeysBitmapCalled       func() []byte
-	GetAggregatedSignatureCalled func() []byte
-	GetHeaderHashCalled          func() []byte
-	GetHeaderEpochCalled         func() uint32
-	GetHeaderNonceCalled         func() uint64
-	GetHeaderShardIdCalled       func() uint32
-	GetHeaderRoundCalled         func() uint64
-	GetIsStartOfEpochCalled      func() bool
+	GetPubKeysBitmapCalled          func() []byte
+	GetAggregatedSignatureCalled    func() []byte
+	GetHeaderHashCalled             func() []byte
+	GetHeaderEpochCalled            func() uint32
+	GetHeaderNonceCalled            func() uint64
+	GetHeaderShardIdCalled          func() uint32
+	GetHeaderRoundCalled            func() uint64
+	GetIsStartOfEpochCalled         func() bool
+	GetExtraSignatureHandlersCalled func() map[string]data.ExtraSignatureDataHandler
+}
+
+func (h *HeaderProofHandlerStub) GetExtraSignatureHandlers() map[string]data.ExtraSignatureDataHandler {
+	if h.GetExtraSignatureHandlersCalled != nil {
+		return h.GetExtraSignatureHandlersCalled()
+	}
+
+	return nil
 }
 
 // GetPubKeysBitmap -

--- a/testscommon/subRounds/subRoundEndExtraSignatureAggregatorHandlerMock.go
+++ b/testscommon/subRounds/subRoundEndExtraSignatureAggregatorHandlerMock.go
@@ -2,6 +2,7 @@ package subRounds
 
 import (
 	"github.com/multiversx/mx-chain-core-go/data"
+
 	"github.com/multiversx/mx-chain-go/consensus"
 )
 
@@ -13,6 +14,7 @@ type SubRoundEndExtraSignatureMock struct {
 	SetAggregatedSignatureInHeaderCalled   func(header data.HeaderHandler, aggregatedSig []byte) error
 	HaveConsensusHeaderWithFullInfoCalled  func(header data.HeaderHandler, cnsMsg *consensus.Message) error
 	VerifyAggregatedSignaturesCalled       func(bitmap []byte, header data.HeaderHandler) error
+	GetLeaderExtraSigCalled                func(header data.HeaderHandler) ([]byte, error)
 	IdentifierCalled                       func() string
 }
 
@@ -62,6 +64,15 @@ func (mock *SubRoundEndExtraSignatureMock) VerifyAggregatedSignatures(bitmap []b
 		return mock.VerifyAggregatedSignaturesCalled(bitmap, header)
 	}
 	return nil
+}
+
+// GetLeaderExtraSig -
+func (mock *SubRoundEndExtraSignatureMock) GetLeaderExtraSig(header data.HeaderHandler) ([]byte, error) {
+	if mock.GetLeaderExtraSigCalled != nil {
+		return mock.GetLeaderExtraSigCalled(header)
+	}
+
+	return nil, nil
 }
 
 // Identifier -

--- a/testscommon/subRounds/subRoundEndExtraSignersHolderMock.go
+++ b/testscommon/subRounds/subRoundEndExtraSignersHolderMock.go
@@ -2,6 +2,7 @@ package subRounds
 
 import (
 	"github.com/multiversx/mx-chain-core-go/data"
+
 	"github.com/multiversx/mx-chain-go/consensus"
 )
 
@@ -13,6 +14,7 @@ type SubRoundEndExtraSignersHolderMock struct {
 	SetAggregatedSignatureInHeaderCalled            func(header data.HeaderHandler, aggregatedSigs map[string][]byte) error
 	VerifyAggregatedSignaturesCalled                func(bitmap []byte, header data.HeaderHandler) error
 	HaveConsensusHeaderWithFullInfoCalled           func(header data.HeaderHandler, cnsMsg *consensus.Message) error
+	GetLeaderExtraSigCalled                         func(header data.HeaderHandler, id string) ([]byte, error)
 	RegisterExtraEndRoundSigAggregatorHandlerCalled func(extraSigner consensus.SubRoundEndExtraSignatureHandler) error
 }
 
@@ -62,6 +64,15 @@ func (mock *SubRoundEndExtraSignersHolderMock) HaveConsensusHeaderWithFullInfo(h
 		return mock.HaveConsensusHeaderWithFullInfoCalled(header, cnsMsg)
 	}
 	return nil
+}
+
+// GetLeaderExtraSig -
+func (mock *SubRoundEndExtraSignersHolderMock) GetLeaderExtraSig(header data.HeaderHandler, id string) ([]byte, error) {
+	if mock.GetLeaderExtraSigCalled != nil {
+		return mock.GetLeaderExtraSigCalled(header, id)
+	}
+
+	return nil, nil
 }
 
 // RegisterExtraSigningHandler -


### PR DESCRIPTION
## Reasoning behind the pull request
- Integrated extra signatures in header proof
  
## Proposed changes
- Adapted leader/aggregated signature w.r.t the way andromeda consensus works by having:
-- leader will add `leader signature` on `hash(operation)` in `subRoundBlock`
-- participants will add their signatures in `subRoundEnd`, everyone can aggregate them and create+broadcast proof
- Integrated extra signers verification in header proof verification

## Testing procedure
- 
- 
- 

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
