### PR TITLE
Fix sync nodes

### DIFF
--- a/cmd/node/config/config.toml
+++ b/cmd/node/config/config.toml
@@ -685,7 +685,7 @@
 [StateTriesConfig]
     SnapshotsEnabled = true
     AccountsStatePruningEnabled = false
-    PeerStatePruningEnabled = true
+    PeerStatePruningEnabled = false
     MaxStateTrieLevelInMemory = 5
     MaxPeerTrieLevelInMemory = 5
     StateStatisticsEnabled = false

--- a/cmd/sovereignnode/config/enableEpochs.toml
+++ b/cmd/sovereignnode/config/enableEpochs.toml
@@ -343,7 +343,7 @@
     ConsensusModelV2EnableEpoch = 0
 
     # AndromedaEnableEpoch represents the epoch when the equivalent messages and fix order for consensus features are enabled
-    AndromedaEnableEpoch = 2
+    AndromedaEnableEpoch = 0
 
     # BLSMultiSignerEnableEpoch represents the activation epoch for different types of BLS multi-signers
     BLSMultiSignerEnableEpoch = [

--- a/consensus/spos/worker.go
+++ b/consensus/spos/worker.go
@@ -886,15 +886,6 @@ func (wrk *Worker) removeConsensusHeaderFromPool() {
 	if check.IfNil(header) {
 		return
 	}
-	originalHeaderhash := headerHash
-	headerHash, err := core.CalculateHash(wrk.marshalizer, wrk.hasher, header)
-	if err != nil {
-		log.Error("removeConsensusHeaderFromPool failed to calculate header hash", "err", err)
-	}
-
-	log.Error("removeConsensusHeaderFromPool calculated header hash", "headerHash", headerHash,
-		"original header Hash", originalHeaderhash,
-	)
 
 	if !wrk.enableEpochsHandler.IsFlagEnabledInEpoch(common.AndromedaFlag, header.GetEpoch()) {
 		return
@@ -906,8 +897,21 @@ func (wrk *Worker) removeConsensusHeaderFromPool() {
 		return
 	}
 
+	processedHeaderHash, err := core.CalculateHash(wrk.marshalizer, wrk.hasher, header)
+	if err != nil {
+		log.Error("removeConsensusHeaderFromPool: failed to calculate header hash", "err", err)
+		return
+	}
+
+	log.Debug("removeConsensusHeaderFromPool", "headerHash", headerHash,
+		"processedHeaderHash", processedHeaderHash,
+	)
+
 	blockProcessorWithPoolAccess.RemoveHeaderFromPool(headerHash)
 	wrk.forkDetector.RemoveHeader(header.GetNonce(), headerHash)
+
+	blockProcessorWithPoolAccess.RemoveHeaderFromPool(processedHeaderHash)
+	wrk.forkDetector.RemoveHeader(header.GetNonce(), processedHeaderHash)
 }
 
 // DisplayStatistics logs the consensus messages split on proposed headers

--- a/consensus/spos/worker.go
+++ b/consensus/spos/worker.go
@@ -886,6 +886,15 @@ func (wrk *Worker) removeConsensusHeaderFromPool() {
 	if check.IfNil(header) {
 		return
 	}
+	originalHeaderhash := headerHash
+	headerHash, err := core.CalculateHash(wrk.marshalizer, wrk.hasher, header)
+	if err != nil {
+		log.Error("removeConsensusHeaderFromPool failed to calculate header hash", "err", err)
+	}
+
+	log.Error("removeConsensusHeaderFromPool calculated header hash", "headerHash", headerHash,
+		"original header Hash", originalHeaderhash,
+	)
 
 	if !wrk.enableEpochsHandler.IsFlagEnabledInEpoch(common.AndromedaFlag, header.GetEpoch()) {
 		return

--- a/consensus/spos/worker_test.go
+++ b/consensus/spos/worker_test.go
@@ -2122,6 +2122,40 @@ func TestWorker_ExtendShouldWork(t *testing.T) {
 	assert.Equal(t, int32(1), atomic.LoadInt32(&executed))
 }
 
+func TestWorker_ExtendShouldWorkInAndromeda(t *testing.T) {
+	t.Parallel()
+	wrk := *initWorker(&statusHandlerMock.AppStatusHandlerStub{})
+	enableEpochsHandler := &enableEpochsHandlerMock.EnableEpochsHandlerStub{
+		IsFlagEnabledInEpochCalled: func(flag core.EnableEpochFlag, epoch uint32) bool {
+			return flag == common.AndromedaFlag
+		},
+	}
+	wrk.SetEnableEpochsHandler(enableEpochsHandler)
+
+	hdrHash := []byte("hdrHash")
+	currHdr := &block.Header{Epoch: 4}
+	currHdrHash, err := core.CalculateHash(wrk.Marshalizer(), &hashingMocks.HasherMock{}, currHdr)
+	require.Nil(t, err)
+
+	removedHdrsMap := map[string]struct{}{
+		string(hdrHash):     {},
+		string(currHdrHash): {},
+	}
+	blockProcessor := &testscommon.BlockProcessorStub{
+		RemoveHeaderFromPoolCalled: func(headerHash []byte) {
+			delete(removedHdrsMap, string(headerHash))
+		},
+	}
+
+	wrk.ConsensusState().SetData(hdrHash)
+	wrk.ConsensusState().SetHeader(currHdr)
+
+	wrk.SetBlockProcessor(blockProcessor)
+	wrk.Extend(1)
+	time.Sleep(1000 * time.Millisecond)
+	require.Empty(t, removedHdrsMap)
+}
+
 func TestWorker_ExecuteStoredMessagesShouldWork(t *testing.T) {
 	t.Parallel()
 	wrk := *initWorker(&statusHandlerMock.AppStatusHandlerStub{})

--- a/epochStart/metachain/sovereignTrigger.go
+++ b/epochStart/metachain/sovereignTrigger.go
@@ -162,7 +162,8 @@ func (st *sovereignTrigger) shouldUpdateTrigger(headerHandler data.HeaderHandler
 		return false
 	}
 
-	isMetaStartOfEpochForCurrentOrOlderEpoch := headerHandler.GetEpoch() <= st.epoch
+	isMetaStartOfEpochForCurrentOrOlderEpoch := (headerHandler.GetEpoch() <= st.epoch+1) &&
+		(headerHandler.GetRound()-1 == st.currentRound)
 	if isMetaStartOfEpochForCurrentOrOlderEpoch {
 		return false
 	}

--- a/epochStart/metachain/sovereignTrigger_test.go
+++ b/epochStart/metachain/sovereignTrigger_test.go
@@ -184,11 +184,13 @@ func TestSovereignTrigger_receivedBlock(t *testing.T) {
 	}
 
 	sovTrigger, _ := NewSovereignTrigger(args)
+	sovTrigger.currentRound = 3
 
 	// header is for current epoch, will not notify
 	sovHdr := &block.SovereignChainHeader{
 		Header: &block.Header{
 			Epoch: 4,
+			Round: 4,
 		},
 		IsStartOfEpoch: true,
 	}
@@ -201,6 +203,7 @@ func TestSovereignTrigger_receivedBlock(t *testing.T) {
 	require.False(t, wereValidatorsAdded)
 
 	sovTrigger.epoch = 3
+	_ = sovHdr.SetRound(3)
 	sovTrigger.receivedBlock(sovHdr, nil)
 	require.True(t, wasNotifyPrepareCalled)
 	require.True(t, wasNotifyEpochChangeCalled)

--- a/process/sync/baseSync.go
+++ b/process/sync/baseSync.go
@@ -407,7 +407,7 @@ func (boot *baseBootstrap) waitForHeaderAndProofByNonce() error {
 	case <-boot.chRcvHdrNonce:
 		return nil
 	case <-time.After(boot.waitTime):
-		log.Error("waitForHeaderAndProofByNonce")
+		log.Error("waitForHeaderAndProofByNonce timeout")
 		return process.ErrTimeIsOut
 	}
 }
@@ -418,7 +418,7 @@ func (boot *baseBootstrap) waitForHeaderAndProofByHash() error {
 	case <-boot.chRcvHdrHash:
 		return nil
 	case <-time.After(boot.waitTime):
-		log.Error("waitForHeaderAndProofByHash")
+		log.Error("waitForHeaderAndProofByHash timeout")
 		return process.ErrTimeIsOut
 	}
 }
@@ -1529,7 +1529,7 @@ func (boot *baseBootstrap) waitForMiniBlocks() error {
 	case <-boot.chRcvMiniBlocks:
 		return nil
 	case <-time.After(boot.waitTime):
-		log.Error("waitForMiniBlocks")
+		log.Error("waitForMiniBlocks timeout")
 		return process.ErrTimeIsOut
 	}
 }

--- a/process/sync/baseSync.go
+++ b/process/sync/baseSync.go
@@ -407,6 +407,7 @@ func (boot *baseBootstrap) waitForHeaderAndProofByNonce() error {
 	case <-boot.chRcvHdrNonce:
 		return nil
 	case <-time.After(boot.waitTime):
+		log.Error("waitForHeaderAndProofByNonce")
 		return process.ErrTimeIsOut
 	}
 }
@@ -417,6 +418,7 @@ func (boot *baseBootstrap) waitForHeaderAndProofByHash() error {
 	case <-boot.chRcvHdrHash:
 		return nil
 	case <-time.After(boot.waitTime):
+		log.Error("waitForHeaderAndProofByHash")
 		return process.ErrTimeIsOut
 	}
 }
@@ -1527,6 +1529,7 @@ func (boot *baseBootstrap) waitForMiniBlocks() error {
 	case <-boot.chRcvMiniBlocks:
 		return nil
 	case <-time.After(boot.waitTime):
+		log.Error("waitForMiniBlocks")
 		return process.ErrTimeIsOut
 	}
 }

--- a/testscommon/blockProcessorStub.go
+++ b/testscommon/blockProcessorStub.go
@@ -24,6 +24,7 @@ type BlockProcessorStub struct {
 	CreateNewHeaderCalled            func(round uint64, nonce uint64) (data.HeaderHandler, error)
 	RevertStateToBlockCalled         func(header data.HeaderHandler, rootHash []byte) error
 	NonceOfFirstCommittedBlockCalled func() core.OptionalUint64
+	RemoveHeaderFromPoolCalled       func(headerHash []byte)
 	CloseCalled                      func() error
 }
 
@@ -155,6 +156,13 @@ func (bps *BlockProcessorStub) NonceOfFirstCommittedBlock() core.OptionalUint64 
 
 	return core.OptionalUint64{
 		HasValue: false,
+	}
+}
+
+// RemoveHeaderFromPool -
+func (bps *BlockProcessorStub) RemoveHeaderFromPool(headerHash []byte) {
+	if bps.RemoveHeaderFromPoolCalled != nil {
+		bps.RemoveHeaderFromPoolCalled(headerHash)
 	}
 }
 

--- a/testscommon/processMocks/forkDetectorStub.go
+++ b/testscommon/processMocks/forkDetectorStub.go
@@ -39,7 +39,9 @@ func (fdm *ForkDetectorStub) AddHeader(header data.HeaderHandler, hash []byte, s
 
 // RemoveHeader -
 func (fdm *ForkDetectorStub) RemoveHeader(nonce uint64, hash []byte) {
-	fdm.RemoveHeaderCalled(nonce, hash)
+	if fdm.RemoveHeaderCalled != nil {
+		fdm.RemoveHeaderCalled(nonce, hash)
+	}
 }
 
 // CheckFork -


### PR DESCRIPTION
## Reasoning behind the pull request
- Several fixes to have nodes that restart working
  
## Proposed changes
- `AndromedaEnableEpoch` set to zero
- `PeerStatePruningEnabled` set to false to get rid of `get node from db error` for syncing nodes
- Remove processed header hash data from pool on reverts
- Do not trigger data request mechanism for current epoch change

## Testing procedure
- 
- 
- 

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
