### PR TITLE
Extend outgoing op formatter

### DIFF
--- a/process/block/sovereign/errors.go
+++ b/process/block/sovereign/errors.go
@@ -9,3 +9,5 @@ var errNoSubscribedIdentifier = errors.New("no subscribed identifier provided")
 var errNoSubscribedEvent = errors.New("no subscribed event provided")
 
 var errDuplicateSubscribedAddresses = errors.New("duplicate subscribed addresses provided")
+
+var errEventIDNotFound = errors.New("eventID not found")

--- a/process/block/sovereign/interface.go
+++ b/process/block/sovereign/interface.go
@@ -28,3 +28,8 @@ type TopicsCheckerHandler interface {
 	CheckValidity(topics [][]byte, transferData *sovereign.TransferData) error
 	IsInterfaceNil() bool
 }
+
+// OperationFormatter defines an operation formatter(like deposit tokens)
+type OperationFormatter interface {
+	CreateOperationData(event data.EventHandler, evData *sovereign.EventData) ([]byte, error)
+}

--- a/process/block/sovereign/interface.go
+++ b/process/block/sovereign/interface.go
@@ -32,4 +32,5 @@ type TopicsCheckerHandler interface {
 // OperationFormatter defines an operation formatter(like deposit tokens)
 type OperationFormatter interface {
 	CreateOperationData(event data.EventHandler, evData *sovereign.EventData) ([]byte, error)
+	IsInterfaceNil() bool
 }

--- a/process/block/sovereign/operationFormatters/depositOpFormatter.go
+++ b/process/block/sovereign/operationFormatters/depositOpFormatter.go
@@ -1,0 +1,62 @@
+package operationFormatters
+
+import (
+	"github.com/multiversx/mx-chain-core-go/data"
+	sovereign2 "github.com/multiversx/mx-chain-core-go/data/sovereign"
+	"github.com/multiversx/mx-chain-go/common"
+	"github.com/multiversx/mx-chain-go/process/block/sovereign"
+)
+
+const (
+	numTransferTopics = 3
+	tokensIndex       = 2
+	receiverIndex     = 1
+)
+
+type depositOpFormatter struct {
+	subscribedEvents []sovereign.SubscribedEvent
+	topicsChecker    sovereign.TopicsCheckerHandler
+	dataCodec        sovereign.DataCodecHandler
+}
+
+func (op *depositOpFormatter) CreateOperationData(event data.EventHandler, evData *sovereign2.EventData) ([]byte, error) {
+	operation, err := op.createOperationData(event.GetTopics(), evData)
+	if err != nil {
+		return nil, err
+	}
+
+	operationBytes, err := op.dataCodec.SerializeOperation(*operation)
+	if err != nil {
+		return nil, err
+	}
+
+	return operationBytes, nil
+}
+
+func (op *depositOpFormatter) createOperationData(topics [][]byte, eventData *sovereign2.EventData) (*sovereign2.Operation, error) {
+	tokens := make([]sovereign2.EsdtToken, 0)
+	for i := tokensIndex; i < len(topics); i += numTransferTopics {
+		tokenIdentifier := topics[i]
+		tokenNonce, err := common.ByteSliceToUint64(topics[i+1])
+		if err != nil {
+			return nil, err
+		}
+		tokenData, err := op.dataCodec.DeserializeTokenData(topics[i+2])
+		if err != nil {
+			return nil, err
+		}
+
+		payment := sovereign2.EsdtToken{
+			Identifier: tokenIdentifier,
+			Nonce:      tokenNonce,
+			Data:       *tokenData,
+		}
+		tokens = append(tokens, payment)
+	}
+
+	return &sovereign2.Operation{
+		Address: topics[receiverIndex],
+		Tokens:  tokens,
+		Data:    eventData,
+	}, nil
+}

--- a/process/block/sovereign/operationFormatters/depositOpFormatter.go
+++ b/process/block/sovereign/operationFormatters/depositOpFormatter.go
@@ -1,9 +1,11 @@
 package operationFormatters
 
 import (
+	"github.com/multiversx/mx-chain-core-go/core/check"
 	"github.com/multiversx/mx-chain-core-go/data"
-	sovereign2 "github.com/multiversx/mx-chain-core-go/data/sovereign"
+	sovData "github.com/multiversx/mx-chain-core-go/data/sovereign"
 	"github.com/multiversx/mx-chain-go/common"
+	errMx "github.com/multiversx/mx-chain-go/errors"
 )
 
 const (
@@ -16,13 +18,19 @@ type depositOpFormatter struct {
 	dataCodec DataCodecHandler
 }
 
+// NewDepositOpFormatter creates a new deposit token operation formatter
 func NewDepositOpFormatter(dataCodec DataCodecHandler) (*depositOpFormatter, error) {
+	if check.IfNil(dataCodec) {
+		return nil, errMx.ErrNilDataCodec
+	}
+
 	return &depositOpFormatter{
 		dataCodec: dataCodec,
 	}, nil
 }
 
-func (op *depositOpFormatter) CreateOperationData(event data.EventHandler, evData *sovereign2.EventData) ([]byte, error) {
+// CreateOperationData creates a deposit token operation data bytes
+func (op *depositOpFormatter) CreateOperationData(event data.EventHandler, evData *sovData.EventData) ([]byte, error) {
 	operation, err := op.createOperationData(event.GetTopics(), evData)
 	if err != nil {
 		return nil, err
@@ -36,8 +44,8 @@ func (op *depositOpFormatter) CreateOperationData(event data.EventHandler, evDat
 	return operationBytes, nil
 }
 
-func (op *depositOpFormatter) createOperationData(topics [][]byte, eventData *sovereign2.EventData) (*sovereign2.Operation, error) {
-	tokens := make([]sovereign2.EsdtToken, 0)
+func (op *depositOpFormatter) createOperationData(topics [][]byte, eventData *sovData.EventData) (*sovData.Operation, error) {
+	tokens := make([]sovData.EsdtToken, 0)
 	for i := tokensIndex; i < len(topics); i += numTransferTopics {
 		tokenIdentifier := topics[i]
 		tokenNonce, err := common.ByteSliceToUint64(topics[i+1])
@@ -49,7 +57,7 @@ func (op *depositOpFormatter) createOperationData(topics [][]byte, eventData *so
 			return nil, err
 		}
 
-		payment := sovereign2.EsdtToken{
+		payment := sovData.EsdtToken{
 			Identifier: tokenIdentifier,
 			Nonce:      tokenNonce,
 			Data:       *tokenData,
@@ -57,9 +65,14 @@ func (op *depositOpFormatter) createOperationData(topics [][]byte, eventData *so
 		tokens = append(tokens, payment)
 	}
 
-	return &sovereign2.Operation{
+	return &sovData.Operation{
 		Address: topics[receiverIndex],
 		Tokens:  tokens,
 		Data:    eventData,
 	}, nil
+}
+
+// IsInterfaceNil checks if the underlying pointer is nil
+func (op *depositOpFormatter) IsInterfaceNil() bool {
+	return op == nil
 }

--- a/process/block/sovereign/operationFormatters/depositOpFormatter.go
+++ b/process/block/sovereign/operationFormatters/depositOpFormatter.go
@@ -4,7 +4,6 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data"
 	sovereign2 "github.com/multiversx/mx-chain-core-go/data/sovereign"
 	"github.com/multiversx/mx-chain-go/common"
-	"github.com/multiversx/mx-chain-go/process/block/sovereign"
 )
 
 const (
@@ -14,9 +13,13 @@ const (
 )
 
 type depositOpFormatter struct {
-	subscribedEvents []sovereign.SubscribedEvent
-	topicsChecker    sovereign.TopicsCheckerHandler
-	dataCodec        sovereign.DataCodecHandler
+	dataCodec DataCodecHandler
+}
+
+func NewDepositOpFormatter(dataCodec DataCodecHandler) (*depositOpFormatter, error) {
+	return &depositOpFormatter{
+		dataCodec: dataCodec,
+	}, nil
 }
 
 func (op *depositOpFormatter) CreateOperationData(event data.EventHandler, evData *sovereign2.EventData) ([]byte, error) {

--- a/process/block/sovereign/operationFormatters/depositOpFormatter_test.go
+++ b/process/block/sovereign/operationFormatters/depositOpFormatter_test.go
@@ -1,0 +1,24 @@
+package operationFormatters
+
+import (
+	"testing"
+
+	errMx "github.com/multiversx/mx-chain-go/errors"
+	"github.com/multiversx/mx-chain-go/testscommon/sovereign"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewDepositOpFormatter(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil data codec, should return error", func(t *testing.T) {
+		opFormatter, err := NewDepositOpFormatter(nil)
+		require.Nil(t, opFormatter)
+		require.Equal(t, errMx.ErrNilDataCodec, err)
+	})
+	t.Run("should work", func(t *testing.T) {
+		opFormatter, err := NewDepositOpFormatter(&sovereign.DataCodecMock{})
+		require.Nil(t, err)
+		require.False(t, opFormatter.IsInterfaceNil())
+	})
+}

--- a/process/block/sovereign/operationFormatters/interface.go
+++ b/process/block/sovereign/operationFormatters/interface.go
@@ -1,0 +1,10 @@
+package operationFormatters
+
+import "github.com/multiversx/mx-chain-core-go/data/sovereign"
+
+// DataCodecHandler is the interface for serializing/deserializing data
+type DataCodecHandler interface {
+	DeserializeTokenData(data []byte) (*sovereign.EsdtTokenData, error)
+	SerializeOperation(operation sovereign.Operation) ([]byte, error)
+	IsInterfaceNil() bool
+}

--- a/process/block/sovereign/outgoingOperations.go
+++ b/process/block/sovereign/outgoingOperations.go
@@ -7,22 +7,18 @@ import (
 	"github.com/multiversx/mx-chain-core-go/core/check"
 	"github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-core-go/data/sovereign"
+	"github.com/multiversx/mx-chain-go/process/block/sovereign/operationFormatters"
 	logger "github.com/multiversx/mx-chain-logger-go"
 	"google.golang.org/protobuf/proto"
 
-	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/epochStart"
 	"github.com/multiversx/mx-chain-go/errors"
 	"github.com/multiversx/mx-chain-go/state"
 )
 
-var log = logger.GetOrCreate("outgoing-operations")
+const topicIDDeposit = "deposit"
 
-const (
-	numTransferTopics = 3
-	tokensIndex       = 2
-	receiverIndex     = 1
-)
+var log = logger.GetOrCreate("outgoing-operations")
 
 // SubscribedEvent contains a subscribed event from the sovereign chain needed to be transferred to the main chain
 type SubscribedEvent struct {
@@ -42,6 +38,8 @@ type outgoingOperations struct {
 	dataCodec        DataCodecHandler
 	topicsChecker    TopicsCheckerHandler
 	peerAccountsDB   state.AccountsAdapter
+
+	opFormatters map[string]OperationFormatter
 }
 
 // TODO: We should create a common base functionality from this component. Similar behavior is also found in
@@ -59,11 +57,20 @@ func NewOutgoingOperationsFormatter(args ArgsOutgoingOperations) (*outgoingOpera
 		return nil, err
 	}
 
+	depositOutGoingOpFormatter, err := operationFormatters.NewDepositOpFormatter(args.DataCodec)
+	if err != nil {
+		return nil, err
+	}
+	opFormatters := map[string]OperationFormatter{
+		topicIDDeposit: depositOutGoingOpFormatter,
+	}
+
 	return &outgoingOperations{
 		subscribedEvents: args.SubscribedEvents,
 		dataCodec:        args.DataCodec,
 		topicsChecker:    args.TopicsChecker,
 		peerAccountsDB:   args.PeerAccountsDB,
+		opFormatters:     opFormatters,
 	}, nil
 }
 
@@ -203,45 +210,13 @@ func (op *outgoingOperations) getOperationData(event data.EventHandler) ([]byte,
 		return nil, err
 	}
 
-	operation, err := op.createOperationData(topics, evData)
-	if err != nil {
-		return nil, err
+	opFormatter, found := op.opFormatters[string(event.GetIdentifier())]
+	if !found {
+		log.Error("outgoingOperations.getOperationData: event not found", "event", string(event.GetIdentifier()))
+		return nil, errEventIDNotFound
 	}
 
-	operationBytes, err := op.dataCodec.SerializeOperation(*operation)
-	if err != nil {
-		return nil, err
-	}
-
-	return operationBytes, nil
-}
-
-func (op *outgoingOperations) createOperationData(topics [][]byte, eventData *sovereign.EventData) (*sovereign.Operation, error) {
-	tokens := make([]sovereign.EsdtToken, 0)
-	for i := tokensIndex; i < len(topics); i += numTransferTopics {
-		tokenIdentifier := topics[i]
-		tokenNonce, err := common.ByteSliceToUint64(topics[i+1])
-		if err != nil {
-			return nil, err
-		}
-		tokenData, err := op.dataCodec.DeserializeTokenData(topics[i+2])
-		if err != nil {
-			return nil, err
-		}
-
-		payment := sovereign.EsdtToken{
-			Identifier: tokenIdentifier,
-			Nonce:      tokenNonce,
-			Data:       *tokenData,
-		}
-		tokens = append(tokens, payment)
-	}
-
-	return &sovereign.Operation{
-		Address: topics[receiverIndex],
-		Tokens:  tokens,
-		Data:    eventData,
-	}, nil
+	return opFormatter.CreateOperationData(event, evData)
 }
 
 // CreateOutGoingChangeValidatorData will create the necessary outgoing data for validator set change

--- a/process/block/sovereign/outgoingOperations_test.go
+++ b/process/block/sovereign/outgoingOperations_test.go
@@ -73,7 +73,7 @@ func TestNewOutgoingOperationsFormatter(t *testing.T) {
 	})
 }
 
-func createOutgoingOpsFormatter() *outgoingOperations {
+func createArgsOutGoingOpsFormatterWithEvents() ArgsOutgoingOperations {
 	events := []SubscribedEvent{
 		{
 			Identifier: []byte("deposit"),
@@ -84,12 +84,16 @@ func createOutgoingOpsFormatter() *outgoingOperations {
 		},
 	}
 
-	args := ArgsOutgoingOperations{
+	return ArgsOutgoingOperations{
 		SubscribedEvents: events,
 		DataCodec:        &sovTests.DataCodecMock{},
 		TopicsChecker:    &sovTests.TopicsCheckerMock{},
 		PeerAccountsDB:   &state.AccountsStub{},
 	}
+}
+
+func createOutgoingOpsFormatter() *outgoingOperations {
+	args := createArgsOutGoingOpsFormatterWithEvents()
 	opFormatter, _ := NewOutgoingOperationsFormatter(args)
 	return opFormatter
 }
@@ -179,13 +183,15 @@ func TestOutgoingOperations_CreateOutgoingTxsDataErrorCases(t *testing.T) {
 	t.Run("deserialize token error", func(t *testing.T) {
 		t.Parallel()
 
-		outgoingOpsFormatter := createOutgoingOpsFormatter()
+		args := createArgsOutGoingOpsFormatterWithEvents()
+
 		errDeserializeTokenData := fmt.Errorf("deserialize token data error")
-		outgoingOpsFormatter.dataCodec = &sovTests.DataCodecMock{
+		args.DataCodec = &sovTests.DataCodecMock{
 			DeserializeTokenDataCalled: func(_ []byte) (*sovereign.EsdtTokenData, error) {
 				return nil, errDeserializeTokenData
 			},
 		}
+		outgoingOpsFormatter, _ := NewOutgoingOperationsFormatter(args)
 
 		outgoingTxData, err := outgoingOpsFormatter.CreateOutgoingTxsData(logs)
 		require.Nil(t, outgoingTxData)
@@ -209,13 +215,15 @@ func TestOutgoingOperations_CreateOutgoingTxsDataErrorCases(t *testing.T) {
 	t.Run("serialize operation error", func(t *testing.T) {
 		t.Parallel()
 
-		outgoingOpsFormatter := createOutgoingOpsFormatter()
+		args := createArgsOutGoingOpsFormatterWithEvents()
+
 		errSerializeOperation := fmt.Errorf("serialize operation error")
-		outgoingOpsFormatter.dataCodec = &sovTests.DataCodecMock{
+		args.DataCodec = &sovTests.DataCodecMock{
 			SerializeOperationCalled: func(operation sovereign.Operation) ([]byte, error) {
 				return nil, errSerializeOperation
 			},
 		}
+		outgoingOpsFormatter, _ := NewOutgoingOperationsFormatter(args)
 
 		outgoingTxData, err := outgoingOpsFormatter.CreateOutgoingTxsData(logs)
 		require.Nil(t, outgoingTxData)


### PR DESCRIPTION
## Reasoning behind the pull request
- Extended outgoing op formatter
  
## Proposed changes
- Refactored outGoingOperation formatter to contain a map of different op formatters for future integrations

## Testing procedure
- 
- 
- 

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
