### PR TITLE
Multi outgoing mb types

### DIFF
--- a/cmd/sovereignnode/chainSimulator/tests/epochChange/epochChange_test.go
+++ b/cmd/sovereignnode/chainSimulator/tests/epochChange/epochChange_test.go
@@ -288,38 +288,6 @@ func checkEpochChangeRewardsMB(
 	require.Empty(t, owners)
 }
 
-func checkOutGoingMiniBlockRegisterValidator(
-	t *testing.T,
-	nodeHandler process.NodeHandler,
-	numOperations int,
-	latestMainChainID int,
-) {
-	nonce, bridgeData := getBridgeDataFromPrevBlock(t, nodeHandler, block.OutGoingMBRegisterBlsKey)
-	require.Equal(t, int32(block.OutGoingMBRegisterBlsKey), bridgeData.Type)
-	require.Len(t, bridgeData.OutGoingOperations, numOperations)
-
-	serializer, _ := abi.NewSerializer(abi.ArgsNewSerializer{PartsSeparator: "@"})
-
-	blsKeys := make([][]byte, 0)
-	assignedMainChainIDs := make([][]byte, 0)
-
-	expectedMainChainIDs := make([][]byte, 0)
-	for _, op := range bridgeData.OutGoingOperations {
-		registeredData := deserializeRegisteredBlsKeyData(t, nodeHandler, serializer, op.Data)
-		require.Equal(t, nonce, registeredData.Nonce)
-
-		blsKeys = append(blsKeys, registeredData.Key)
-		assignedMainChainIDs = append(assignedMainChainIDs, registeredData.ID)
-
-		latestMainChainID++
-		expectedMainChainIDs = append(expectedMainChainIDs, big.NewInt(int64(latestMainChainID)).Bytes())
-	}
-
-	auctionNodes := getAuctionListKeys(t, nodeHandler)
-	require.ElementsMatch(t, expectedMainChainIDs, assignedMainChainIDs)
-	require.Subset(t, auctionNodes, blsKeys)
-}
-
 func deserializeRegisteredBlsKeyData(t *testing.T, nodeHandler process.NodeHandler, serializer dataCodec.AbiSerializer, data []byte) *dto.RegisteredBlsKey {
 	id := &abi.BytesValue{}
 	blsKey := &abi.BytesValue{}

--- a/cmd/sovereignnode/chainSimulator/tests/epochChange/epochChange_test.go
+++ b/cmd/sovereignnode/chainSimulator/tests/epochChange/epochChange_test.go
@@ -140,18 +140,13 @@ func TestSovereignChainSimulator_EpochChange(t *testing.T) {
 	trie := nodeHandler.GetStateComponents().TriesContainer().Get([]byte(dataRetriever.PeerAccountsUnit.String()))
 	require.NotNil(t, trie)
 
-	// Generate enough blocks so that we achieve > 1500 trie storage reads (from MaxNumberOfTrieReadsPerTx gasSchedule cfg)
-	err = cs.GenerateBlocksUntilEpochIsReached(40)
-	require.Nil(t, err)
-	require.Equal(t, uint32(40), nodeHandler.GetCoreComponents().EpochNotifier().CurrentEpoch())
-
 	// all pub key ids from genesis are in ascending order
 	allPubKeyIDs := make([][]byte, 8)
 	for idx := 0; idx < 8; idx++ {
 		allPubKeyIDs[idx] = []byte{byte(idx)}
 	}
 
-	for epoch := 41; epoch <= 45; epoch++ {
+	for epoch := 1; epoch <= 5; epoch++ {
 		err = cs.GenerateBlocksUntilEpochIsReached(int32(epoch))
 		require.Nil(t, err)
 
@@ -210,6 +205,11 @@ func TestSovereignChainSimulator_EpochChange(t *testing.T) {
 		require.NotEmpty(t, accFeesTotal.Bytes())
 		require.Empty(t, devFeesTotal.Bytes())
 	}
+
+	// Generate enough blocks so that we achieve > 1500 trie storage reads (from MaxNumberOfTrieReadsPerTx gasSchedule cfg)
+	err = cs.GenerateBlocksUntilEpochIsReached(45)
+	require.Nil(t, err)
+	require.Equal(t, uint32(45), nodeHandler.GetCoreComponents().EpochNotifier().CurrentEpoch())
 }
 
 func checkEpochChangeHeader(

--- a/cmd/sovereignnode/chainSimulator/tests/epochChange/epochChange_test.go
+++ b/cmd/sovereignnode/chainSimulator/tests/epochChange/epochChange_test.go
@@ -294,8 +294,8 @@ func checkOutGoingMiniBlockRegisterValidator(
 	numOperations int,
 	latestMainChainID int,
 ) {
-	bridgeData := getBridgeDataFromPrevBlock(t, nodeHandler)
-	require.Equal(t, int32(block.OutGoingMbDeposit), bridgeData.Type)
+	nonce, bridgeData := getBridgeDataFromPrevBlock(t, nodeHandler)
+	require.Equal(t, int32(block.OutGoingMBRegisterBlsKey), bridgeData.Type)
 	require.Len(t, bridgeData.OutGoingOperations, numOperations)
 
 	serializer, _ := abi.NewSerializer(abi.ArgsNewSerializer{PartsSeparator: "@"})
@@ -306,6 +306,8 @@ func checkOutGoingMiniBlockRegisterValidator(
 	expectedMainChainIDs := make([][]byte, 0)
 	for _, op := range bridgeData.OutGoingOperations {
 		registeredData := deserializeRegisteredBlsKeyData(t, nodeHandler, serializer, op.Data)
+		require.Equal(t, nonce, registeredData.Nonce)
+
 		blsKeys = append(blsKeys, registeredData.Key)
 		assignedMainChainIDs = append(assignedMainChainIDs, registeredData.ID)
 
@@ -322,6 +324,7 @@ func deserializeRegisteredBlsKeyData(t *testing.T, nodeHandler process.NodeHandl
 	id := &abi.BytesValue{}
 	blsKey := &abi.BytesValue{}
 	owner := &abi.BytesValue{}
+	nonce := &abi.U64Value{}
 
 	abiStruct := &abi.StructValue{
 		Fields: []abi.Field{
@@ -337,6 +340,10 @@ func deserializeRegisteredBlsKeyData(t *testing.T, nodeHandler process.NodeHandl
 				Name:  "owner",
 				Value: owner,
 			},
+			{
+				Name:  "nonce",
+				Value: nonce,
+			},
 		},
 	}
 
@@ -350,6 +357,7 @@ func deserializeRegisteredBlsKeyData(t *testing.T, nodeHandler process.NodeHandl
 		ID:    id.Value,
 		Key:   blsKey.Value,
 		Owner: owner.Value,
+		Nonce: nonce.Value,
 	}
 }
 

--- a/cmd/sovereignnode/chainSimulator/tests/epochChange/epochChange_test.go
+++ b/cmd/sovereignnode/chainSimulator/tests/epochChange/epochChange_test.go
@@ -294,7 +294,7 @@ func checkOutGoingMiniBlockRegisterValidator(
 	numOperations int,
 	latestMainChainID int,
 ) {
-	nonce, bridgeData := getBridgeDataFromPrevBlock(t, nodeHandler)
+	nonce, bridgeData := getBridgeDataFromPrevBlock(t, nodeHandler, block.OutGoingMBRegisterBlsKey)
 	require.Equal(t, int32(block.OutGoingMBRegisterBlsKey), bridgeData.Type)
 	require.Len(t, bridgeData.OutGoingOperations, numOperations)
 
@@ -317,7 +317,7 @@ func checkOutGoingMiniBlockRegisterValidator(
 
 	auctionNodes := getAuctionListKeys(t, nodeHandler)
 	require.ElementsMatch(t, expectedMainChainIDs, assignedMainChainIDs)
-	require.ElementsMatch(t, blsKeys, auctionNodes)
+	require.Subset(t, auctionNodes, blsKeys)
 }
 
 func deserializeRegisteredBlsKeyData(t *testing.T, nodeHandler process.NodeHandler, serializer dataCodec.AbiSerializer, data []byte) *dto.RegisteredBlsKey {

--- a/cmd/sovereignnode/chainSimulator/tests/epochChange/epochChange_test.go
+++ b/cmd/sovereignnode/chainSimulator/tests/epochChange/epochChange_test.go
@@ -295,7 +295,7 @@ func checkOutGoingMiniBlockRegisterValidator(
 	latestMainChainID int,
 ) {
 	bridgeData := getBridgeDataFromPrevBlock(t, nodeHandler)
-	require.Equal(t, int32(block.OutGoingMbTx), bridgeData.Type)
+	require.Equal(t, int32(block.OutGoingMbDeposit), bridgeData.Type)
 	require.Len(t, bridgeData.OutGoingOperations, numOperations)
 
 	serializer, _ := abi.NewSerializer(abi.ArgsNewSerializer{PartsSeparator: "@"})

--- a/cmd/sovereignnode/chainSimulator/tests/epochChange/outGoingOps_test.go
+++ b/cmd/sovereignnode/chainSimulator/tests/epochChange/outGoingOps_test.go
@@ -11,11 +11,14 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-core-go/data/block"
 	"github.com/multiversx/mx-chain-core-go/data/sovereign"
+	"github.com/multiversx/mx-chain-core-go/data/transaction"
 	sovereignChainSimulator "github.com/multiversx/mx-chain-go/cmd/sovereignnode/chainSimulator"
+	"github.com/multiversx/mx-chain-go/config"
 	chainSimulatorIntegrationTests "github.com/multiversx/mx-chain-go/integrationTests/chainSimulator"
 	"github.com/multiversx/mx-chain-go/integrationTests/chainSimulator/staking"
 	"github.com/multiversx/mx-chain-go/node/chainSimulator"
 	"github.com/multiversx/mx-chain-go/node/chainSimulator/components/api"
+	"github.com/multiversx/mx-chain-go/node/chainSimulator/dtos"
 	"github.com/multiversx/mx-chain-go/node/chainSimulator/process"
 	"github.com/multiversx/mx-chain-go/vm"
 	"github.com/multiversx/mx-sdk-abi-go/abi"
@@ -27,15 +30,16 @@ var serializer, _ = abi.NewSerializer(abi.ArgsNewSerializer{PartsSeparator: "@"}
 func getBridgeDataFromPrevBlock(
 	t *testing.T,
 	nodeHandler process.NodeHandler,
+	mbType block.OutGoingMBType,
 ) (uint64, *sovereign.BridgeOutGoingData) {
 	prevHdrHash := nodeHandler.GetDataComponents().Blockchain().GetCurrentBlockHeader().GetPrevHash()
 	prevHdr, err := nodeHandler.GetDataComponents().Datapool().Headers().GetHeaderByHash(prevHdrHash)
 	require.Nil(t, err)
 
-	outGoingMBHdrs := prevHdr.(data.SovereignChainHeaderHandler).GetOutGoingMiniBlockHeaderHandlers()
-	require.Len(t, outGoingMBHdrs, 1)
+	outGoingMBHdr := prevHdr.(data.SovereignChainHeaderHandler).GetOutGoingMiniBlockHeaderHandler(int32(mbType))
+	require.NotNil(t, outGoingMBHdr)
 
-	return prevHdr.GetNonce(), nodeHandler.GetRunTypeComponents().OutGoingOperationsPoolHandler().Get(outGoingMBHdrs[0].GetOutGoingOperationsHash())
+	return prevHdr.GetNonce(), nodeHandler.GetRunTypeComponents().OutGoingOperationsPoolHandler().Get(outGoingMBHdr.GetOutGoingOperationsHash())
 }
 
 func checkOutGoingMiniBlockUnRegisterValidator(
@@ -43,17 +47,16 @@ func checkOutGoingMiniBlockUnRegisterValidator(
 	nodeHandler process.NodeHandler,
 	numOperations int,
 	expectedBlsKeys [][]byte,
-	latestMainChainID int,
+	expectedMainChainIDs [][]byte,
 ) {
 	// StakeNodes func from staking/common.go generates one extra block after staking tx, so we need to get
 	// data from previous block
-	nonce, bridgeData := getBridgeDataFromPrevBlock(t, nodeHandler)
+	nonce, bridgeData := getBridgeDataFromPrevBlock(t, nodeHandler, block.OutGoingMBUnRegisterBlsKey)
 	require.Equal(t, int32(block.OutGoingMBUnRegisterBlsKey), bridgeData.Type)
 	require.Len(t, bridgeData.OutGoingOperations, numOperations)
 
 	blsKeys := make([][]byte, 0)
 	assignedMainChainIDs := make([][]byte, 0)
-	expectedMainChainIDs := make([][]byte, 0)
 
 	for _, op := range bridgeData.OutGoingOperations {
 		registeredData := deserializeRegisteredBlsKeyData(t, nodeHandler, serializer, op.Data)
@@ -61,9 +64,6 @@ func checkOutGoingMiniBlockUnRegisterValidator(
 
 		blsKeys = append(blsKeys, registeredData.Key)
 		assignedMainChainIDs = append(assignedMainChainIDs, registeredData.ID)
-
-		expectedMainChainIDs = append(expectedMainChainIDs, big.NewInt(int64(latestMainChainID)).Bytes())
-		latestMainChainID--
 	}
 
 	require.ElementsMatch(t, expectedMainChainIDs, assignedMainChainIDs)
@@ -79,6 +79,54 @@ func getBlsKeyBytes(t *testing.T, keys []string) [][]byte {
 	}
 
 	return blsKeys
+}
+
+func createStakeTxs(
+	nonce *uint64,
+	walletAddress dtos.WalletAddress,
+	blsKeys []string,
+) []*transaction.Transaction {
+	txs := make([]*transaction.Transaction, len(blsKeys))
+	for i := 0; i < len(blsKeys); i++ {
+		txDataField := fmt.Sprintf("stake@01@%s@%s", blsKeys[i], staking.MockBLSSignature)
+		txStake := chainSimulatorIntegrationTests.GenerateTransaction(
+			walletAddress.Bytes,
+			*nonce,
+			vm.ValidatorSCAddress,
+			chainSimulatorIntegrationTests.MinimumStakeValue,
+			txDataField,
+			staking.GasLimitForStakeOperation,
+		)
+
+		txs[i] = txStake
+		*nonce++
+	}
+
+	return txs
+}
+
+func createUnStakeTxs(
+	nonce *uint64,
+	walletAddress dtos.WalletAddress,
+	blsKeys []string,
+) []*transaction.Transaction {
+	txs := make([]*transaction.Transaction, len(blsKeys))
+
+	for i := 0; i < len(blsKeys); i++ {
+		txUnStake := chainSimulatorIntegrationTests.GenerateTransaction(
+			walletAddress.Bytes,
+			*nonce,
+			vm.ValidatorSCAddress,
+			chainSimulatorIntegrationTests.ZeroValue,
+			fmt.Sprintf("unStake@%s", blsKeys[i]),
+			staking.GasLimitForStakeOperation,
+		)
+
+		txs[i] = txUnStake
+		*nonce++
+	}
+
+	return txs
 }
 
 func TestSovereignChainSimulator_OutgoingOpRegisterAndUnregisterNode(t *testing.T) {
@@ -103,6 +151,9 @@ func TestSovereignChainSimulator_OutgoingOpRegisterAndUnregisterNode(t *testing.
 			ApiInterface:             api.NewNoApiInterface(),
 			MinNodesPerShard:         6,
 			NumNodesWaitingListShard: 2,
+			AlterConfigsFunction: func(cfg *config.Configs) {
+				cfg.SystemSCConfig.StakingSystemSCConfig.NodeLimitPercentage = 1.0
+			},
 		},
 	})
 	require.Nil(t, err)
@@ -110,42 +161,49 @@ func TestSovereignChainSimulator_OutgoingOpRegisterAndUnregisterNode(t *testing.
 
 	defer cs.Close()
 
-	privateKeys, blsKeys, err := chainSimulator.GenerateBlsPrivateKeys(1)
+	privateKeys, blsKeys, err := chainSimulator.GenerateBlsPrivateKeys(4)
 	require.Nil(t, err)
 	err = cs.AddValidatorKeys(privateKeys)
 	require.Nil(t, err)
 
-	mintValue := big.NewInt(0).Mul(chainSimulatorIntegrationTests.OneEGLD, big.NewInt(2600))
+	mintValue := big.NewInt(0).Mul(chainSimulatorIntegrationTests.OneEGLD, big.NewInt(2600*10))
 	walletAddress, err := cs.GenerateAndMintWalletAddress(core.SovereignChainShardId, mintValue)
 	require.Nil(t, err)
 
 	err = cs.GenerateBlocksUntilEpochIsReached(1)
 	require.Nil(t, err)
 
-	txDataField := fmt.Sprintf("stake@01@%s@%s", blsKeys[0], staking.MockBLSSignature)
-	txStake := chainSimulatorIntegrationTests.GenerateTransaction(walletAddress.Bytes, 0, vm.ValidatorSCAddress, chainSimulatorIntegrationTests.MinimumStakeValue, txDataField, staking.GasLimitForStakeOperation)
-	stakeTx, err := cs.SendTxAndGenerateBlockTilTxIsExecuted(txStake, staking.MaxNumOfBlockToGenerateWhenExecutingTx)
+	nonce := uint64(0)
+
+	txs := createStakeTxs(&nonce, walletAddress, blsKeys[:3])
+	txsResults, err := cs.SendTxsAndGenerateBlocksTilAreExecuted(txs, staking.MaxNumOfBlockToGenerateWhenExecutingTx)
 	require.Nil(t, err)
-	require.NotNil(t, stakeTx)
+	require.NotNil(t, txsResults)
 
 	err = cs.GenerateBlocks(1)
 	require.Nil(t, err)
 
-	latestMainChainID := 8 // 8 nodes from genesis
 	nodeHandler := cs.GetNodeHandler(core.SovereignChainShardId)
-	checkOutGoingMiniBlockRegisterValidator(t, nodeHandler, 1, latestMainChainID)
-	latestMainChainID++
+	checkOutGoingMiniBlockRegisterValidator(t, nodeHandler, 3, 8)
 
-	txUnStake := chainSimulatorIntegrationTests.GenerateTransaction(walletAddress.Bytes, 1, vm.ValidatorSCAddress, chainSimulatorIntegrationTests.ZeroValue, fmt.Sprintf("unStake@%s", blsKeys[0]), staking.GasLimitForStakeOperation)
-	unStakeTx, err := cs.SendTxAndGenerateBlockTilTxIsExecuted(txUnStake, staking.MaxNumOfBlockToGenerateWhenExecutingTx)
+	txsUnStake := createUnStakeTxs(&nonce, walletAddress, []string{blsKeys[0], blsKeys[2]})
+	txStakeLastNode := createStakeTxs(&nonce, walletAddress, blsKeys[3:])
+	txsResults, err = cs.SendTxsAndGenerateBlocksTilAreExecuted(append(txsUnStake, txStakeLastNode...), staking.MaxNumOfBlockToGenerateWhenExecutingTx)
 	require.Nil(t, err)
-	require.NotNil(t, unStakeTx)
+	require.NotNil(t, txsResults)
 
 	err = cs.GenerateBlocks(1)
 	require.Nil(t, err)
+
+	err = cs.ForceResetValidatorStatisticsCache()
+	require.Nil(t, err)
+
+	checkOutGoingMiniBlockUnRegisterValidator(t, nodeHandler, 2, getBlsKeyBytes(t, []string{blsKeys[0], blsKeys[2]}), [][]byte{{0x09}, {0x0b}})
+	checkOutGoingMiniBlockRegisterValidator(t, nodeHandler, 1, 8+3)
 
 	blsKeysBytes := getBlsKeyBytes(t, blsKeys)
 	require.Equal(t, "unStaked", staking.GetBLSKeyStatus(t, nodeHandler, blsKeysBytes[0]))
-
-	checkOutGoingMiniBlockUnRegisterValidator(t, nodeHandler, 1, getBlsKeyBytes(t, blsKeys), latestMainChainID)
+	require.Equal(t, "staked", staking.GetBLSKeyStatus(t, nodeHandler, blsKeysBytes[1]))
+	require.Equal(t, "unStaked", staking.GetBLSKeyStatus(t, nodeHandler, blsKeysBytes[2]))
+	require.Equal(t, "staked", staking.GetBLSKeyStatus(t, nodeHandler, blsKeysBytes[3]))
 }

--- a/cmd/sovereignnode/chainSimulator/tests/epochChange/outGoingOps_test.go
+++ b/cmd/sovereignnode/chainSimulator/tests/epochChange/outGoingOps_test.go
@@ -42,6 +42,36 @@ func getBridgeDataFromPrevBlock(
 	return prevHdr.GetNonce(), nodeHandler.GetRunTypeComponents().OutGoingOperationsPoolHandler().Get(outGoingMBHdr.GetOutGoingOperationsHash())
 }
 
+func checkOutGoingMiniBlockRegisterValidator(
+	t *testing.T,
+	nodeHandler process.NodeHandler,
+	numOperations int,
+	latestMainChainID int,
+) {
+	nonce, bridgeData := getBridgeDataFromPrevBlock(t, nodeHandler, block.OutGoingMBRegisterBlsKey)
+	require.Equal(t, int32(block.OutGoingMBRegisterBlsKey), bridgeData.Type)
+	require.Len(t, bridgeData.OutGoingOperations, numOperations)
+
+	blsKeys := make([][]byte, 0)
+	assignedMainChainIDs := make([][]byte, 0)
+
+	expectedMainChainIDs := make([][]byte, 0)
+	for _, op := range bridgeData.OutGoingOperations {
+		registeredData := deserializeRegisteredBlsKeyData(t, nodeHandler, serializer, op.Data)
+		require.Equal(t, nonce, registeredData.Nonce)
+
+		blsKeys = append(blsKeys, registeredData.Key)
+		assignedMainChainIDs = append(assignedMainChainIDs, registeredData.ID)
+
+		latestMainChainID++
+		expectedMainChainIDs = append(expectedMainChainIDs, big.NewInt(int64(latestMainChainID)).Bytes())
+	}
+
+	auctionNodes := getAuctionListKeys(t, nodeHandler)
+	require.ElementsMatch(t, expectedMainChainIDs, assignedMainChainIDs)
+	require.Subset(t, auctionNodes, blsKeys)
+}
+
 func checkOutGoingMiniBlockUnRegisterValidator(
 	t *testing.T,
 	nodeHandler process.NodeHandler,

--- a/cmd/sovereignnode/chainSimulator/tests/epochChange/outGoingOps_test.go
+++ b/cmd/sovereignnode/chainSimulator/tests/epochChange/outGoingOps_test.go
@@ -48,7 +48,7 @@ func checkOutGoingMiniBlockUnRegisterValidator(
 	// StakeNodes func from staking/common.go generates one extra block after staking tx, so we need to get
 	// data from previous block
 	bridgeData := getBridgeDataFromPrevBlock(t, nodeHandler)
-	require.Equal(t, int32(block.OutGoingMbTx), bridgeData.Type)
+	require.Equal(t, int32(block.OutGoingMbDeposit), bridgeData.Type)
 	require.Len(t, bridgeData.OutGoingOperations, numOperations)
 
 	blsKeys := make([][]byte, 0)

--- a/cmd/sovereignnode/chainSimulator/tests/epochChange/outGoingOps_test.go
+++ b/cmd/sovereignnode/chainSimulator/tests/epochChange/outGoingOps_test.go
@@ -27,7 +27,7 @@ var serializer, _ = abi.NewSerializer(abi.ArgsNewSerializer{PartsSeparator: "@"}
 func getBridgeDataFromPrevBlock(
 	t *testing.T,
 	nodeHandler process.NodeHandler,
-) *sovereign.BridgeOutGoingData {
+) (uint64, *sovereign.BridgeOutGoingData) {
 	prevHdrHash := nodeHandler.GetDataComponents().Blockchain().GetCurrentBlockHeader().GetPrevHash()
 	prevHdr, err := nodeHandler.GetDataComponents().Datapool().Headers().GetHeaderByHash(prevHdrHash)
 	require.Nil(t, err)
@@ -35,7 +35,7 @@ func getBridgeDataFromPrevBlock(
 	outGoingMBHdrs := prevHdr.(data.SovereignChainHeaderHandler).GetOutGoingMiniBlockHeaderHandlers()
 	require.Len(t, outGoingMBHdrs, 1)
 
-	return nodeHandler.GetRunTypeComponents().OutGoingOperationsPoolHandler().Get(outGoingMBHdrs[0].GetOutGoingOperationsHash())
+	return prevHdr.GetNonce(), nodeHandler.GetRunTypeComponents().OutGoingOperationsPoolHandler().Get(outGoingMBHdrs[0].GetOutGoingOperationsHash())
 }
 
 func checkOutGoingMiniBlockUnRegisterValidator(
@@ -47,8 +47,8 @@ func checkOutGoingMiniBlockUnRegisterValidator(
 ) {
 	// StakeNodes func from staking/common.go generates one extra block after staking tx, so we need to get
 	// data from previous block
-	bridgeData := getBridgeDataFromPrevBlock(t, nodeHandler)
-	require.Equal(t, int32(block.OutGoingMbDeposit), bridgeData.Type)
+	nonce, bridgeData := getBridgeDataFromPrevBlock(t, nodeHandler)
+	require.Equal(t, int32(block.OutGoingMBUnRegisterBlsKey), bridgeData.Type)
 	require.Len(t, bridgeData.OutGoingOperations, numOperations)
 
 	blsKeys := make([][]byte, 0)
@@ -57,6 +57,8 @@ func checkOutGoingMiniBlockUnRegisterValidator(
 
 	for _, op := range bridgeData.OutGoingOperations {
 		registeredData := deserializeRegisteredBlsKeyData(t, nodeHandler, serializer, op.Data)
+		require.Equal(t, nonce, registeredData.Nonce)
+
 		blsKeys = append(blsKeys, registeredData.Key)
 		assignedMainChainIDs = append(assignedMainChainIDs, registeredData.ID)
 

--- a/cmd/sovereignnode/chainSimulator/tests/epochChange/outGoingOps_test.go
+++ b/cmd/sovereignnode/chainSimulator/tests/epochChange/outGoingOps_test.go
@@ -45,7 +45,6 @@ func getBridgeDataFromPrevBlock(
 func checkOutGoingMiniBlockUnRegisterValidator(
 	t *testing.T,
 	nodeHandler process.NodeHandler,
-	numOperations int,
 	expectedBlsKeys [][]byte,
 	expectedMainChainIDs [][]byte,
 ) {
@@ -53,7 +52,7 @@ func checkOutGoingMiniBlockUnRegisterValidator(
 	// data from previous block
 	nonce, bridgeData := getBridgeDataFromPrevBlock(t, nodeHandler, block.OutGoingMBUnRegisterBlsKey)
 	require.Equal(t, int32(block.OutGoingMBUnRegisterBlsKey), bridgeData.Type)
-	require.Len(t, bridgeData.OutGoingOperations, numOperations)
+	require.Len(t, bridgeData.OutGoingOperations, len(expectedBlsKeys))
 
 	blsKeys := make([][]byte, 0)
 	assignedMainChainIDs := make([][]byte, 0)
@@ -129,6 +128,14 @@ func createUnStakeTxs(
 	return txs
 }
 
+func sendTxsAndGenerateOneBlock(t *testing.T, cs chainSimulatorIntegrationTests.ChainSimulator, txs []*transaction.Transaction) {
+	txsResults, err := cs.SendTxsAndGenerateBlocksTilAreExecuted(txs, staking.MaxNumOfBlockToGenerateWhenExecutingTx)
+	require.Nil(t, err)
+	require.NotNil(t, txsResults)
+	err = cs.GenerateBlocks(1)
+	require.Nil(t, err)
+}
+
 func TestSovereignChainSimulator_OutgoingOpRegisterAndUnregisterNode(t *testing.T) {
 	if testing.Short() {
 		t.Skip("this is not a short test")
@@ -174,34 +181,26 @@ func TestSovereignChainSimulator_OutgoingOpRegisterAndUnregisterNode(t *testing.
 	require.Nil(t, err)
 
 	nonce := uint64(0)
-
-	txs := createStakeTxs(&nonce, walletAddress, blsKeys[:3])
-	txsResults, err := cs.SendTxsAndGenerateBlocksTilAreExecuted(txs, staking.MaxNumOfBlockToGenerateWhenExecutingTx)
-	require.Nil(t, err)
-	require.NotNil(t, txsResults)
-
-	err = cs.GenerateBlocks(1)
-	require.Nil(t, err)
-
 	nodeHandler := cs.GetNodeHandler(core.SovereignChainShardId)
+
+	// Create a block with 3 stake transactions (by staking first 3/4 nodes) and check outgoing mbs
+	txs := createStakeTxs(&nonce, walletAddress, blsKeys[:3])
+	sendTxsAndGenerateOneBlock(t, cs, txs)
 	checkOutGoingMiniBlockRegisterValidator(t, nodeHandler, 3, 8)
 
+	// Create a block with unStake(1/4 & 3/4 nodes) and stake(4/4 node) transactions and check there are two outgoing mbs with
+	// different types
 	txsUnStake := createUnStakeTxs(&nonce, walletAddress, []string{blsKeys[0], blsKeys[2]})
 	txStakeLastNode := createStakeTxs(&nonce, walletAddress, blsKeys[3:])
-	txsResults, err = cs.SendTxsAndGenerateBlocksTilAreExecuted(append(txsUnStake, txStakeLastNode...), staking.MaxNumOfBlockToGenerateWhenExecutingTx)
-	require.Nil(t, err)
-	require.NotNil(t, txsResults)
-
-	err = cs.GenerateBlocks(1)
-	require.Nil(t, err)
+	sendTxsAndGenerateOneBlock(t, cs, append(txsUnStake, txStakeLastNode...))
 
 	err = cs.ForceResetValidatorStatisticsCache()
 	require.Nil(t, err)
 
-	checkOutGoingMiniBlockUnRegisterValidator(t, nodeHandler, 2, getBlsKeyBytes(t, []string{blsKeys[0], blsKeys[2]}), [][]byte{{0x09}, {0x0b}})
-	checkOutGoingMiniBlockRegisterValidator(t, nodeHandler, 1, 8+3)
-
 	blsKeysBytes := getBlsKeyBytes(t, blsKeys)
+	checkOutGoingMiniBlockUnRegisterValidator(t, nodeHandler, [][]byte{blsKeysBytes[0], blsKeysBytes[2]}, [][]byte{{0x09}, {0x0b}})
+	checkOutGoingMiniBlockRegisterValidator(t, nodeHandler, 1, 8+3) // 8 from genesis + 3 staked nodes in total
+
 	require.Equal(t, "unStaked", staking.GetBLSKeyStatus(t, nodeHandler, blsKeysBytes[0]))
 	require.Equal(t, "staked", staking.GetBLSKeyStatus(t, nodeHandler, blsKeysBytes[1]))
 	require.Equal(t, "unStaked", staking.GetBLSKeyStatus(t, nodeHandler, blsKeysBytes[2]))

--- a/cmd/sovereignnode/dataCodec/dataCodec.go
+++ b/cmd/sovereignnode/dataCodec/dataCodec.go
@@ -568,6 +568,10 @@ func getRegisteredKeyData(keyData dto.RegisteredBlsKey) *abi.StructValue {
 				Name:  "owner",
 				Value: &abi.BytesValue{Value: keyData.Owner},
 			},
+			{
+				Name:  "nonce",
+				Value: &abi.U64Value{Value: keyData.Nonce},
+			},
 		},
 	}
 }

--- a/cmd/sovereignnode/dataCodec/dataCodec_test.go
+++ b/cmd/sovereignnode/dataCodec/dataCodec_test.go
@@ -389,6 +389,7 @@ func TestDataCodec_SerializeNewlyRegisteredKey(t *testing.T) {
 		ID:    []byte{0xf1},
 		Key:   []byte("blsKey"),
 		Owner: []byte("owner"),
+		Nonce: 4,
 	}
 	expectedABIStruct := &abi.StructValue{
 		Fields: []abi.Field{
@@ -403,6 +404,10 @@ func TestDataCodec_SerializeNewlyRegisteredKey(t *testing.T) {
 			{
 				Name:  "owner",
 				Value: &abi.BytesValue{Value: blsKeyData.Owner},
+			},
+			{
+				Name:  "nonce",
+				Value: &abi.U64Value{Value: blsKeyData.Nonce},
 			},
 		},
 	}

--- a/consensus/spos/bls/sovereign/sovereignSubRoundEnd_test.go
+++ b/consensus/spos/bls/sovereign/sovereignSubRoundEnd_test.go
@@ -368,7 +368,7 @@ func TestSovereignSubRoundEnd_DoEndJobByLeader(t *testing.T) {
 		wg := sync.WaitGroup{}
 		wg.Add(1)
 		currentBridgeOutGoingData1 := &sovCore.BridgeOutGoingData{
-			Type: int32(block.OutGoingMbTx),
+			Type: int32(block.OutGoingMbDeposit),
 			Hash: outGoingDataHash1,
 			OutGoingOperations: []*sovCore.OutGoingOperation{
 				{
@@ -402,7 +402,7 @@ func TestSovereignSubRoundEnd_DoEndJobByLeader(t *testing.T) {
 				switch string(hash) {
 				case string(outGoingDataHash1):
 					return &sovCore.BridgeOutGoingData{
-						Type: int32(block.OutGoingMbTx),
+						Type: int32(block.OutGoingMbDeposit),
 						Hash: outGoingDataHash1,
 						OutGoingOperations: []*sovCore.OutGoingOperation{
 							{
@@ -463,7 +463,7 @@ func TestSovereignSubRoundEnd_DoEndJobByLeader(t *testing.T) {
 			},
 			OutGoingMiniBlockHeaders: []*block.OutGoingMiniBlockHeader{
 				{
-					Type:                                  block.OutGoingMbTx,
+					Type:                                  block.OutGoingMbDeposit,
 					OutGoingOperationsHash:                outGoingDataHash1,
 					AggregatedSignatureOutGoingOperations: aggregatedSig1,
 					LeaderSignatureOutGoingOperations:     leaderSig1,
@@ -961,7 +961,7 @@ func TestSovereignSubRoundEnd_ReceivedBlockHeaderFinalInfo(t *testing.T) {
 		PubKey:          []byte("A"),
 		InvalidSigners:  []byte("invalidSignersData"),
 		ExtraSignatures: map[string]*consensus.ExtraSignatureData{
-			block.OutGoingMbTx.String(): {
+			block.OutGoingMbDeposit.String(): {
 				AggregatedSignatureOutGoingTxData: aggregatedSig,
 				LeaderSignatureOutGoingTxData:     leaderSig,
 			},
@@ -974,7 +974,7 @@ func TestSovereignSubRoundEnd_ReceivedBlockHeaderFinalInfo(t *testing.T) {
 	require.False(t, wasDataSent)
 
 	// Header's outgoing mb is updated with signatures from consensus message
-	outGoingMb := sovEndRound.GetHeader().(data.SovereignChainHeaderHandler).GetOutGoingMiniBlockHeaderHandler(int32(block.OutGoingMbTx))
+	outGoingMb := sovEndRound.GetHeader().(data.SovereignChainHeaderHandler).GetOutGoingMiniBlockHeaderHandler(int32(block.OutGoingMbDeposit))
 	require.Equal(t, leaderSig, outGoingMb.GetLeaderSignatureOutGoingOperations())
 	require.Equal(t, aggregatedSig, outGoingMb.GetAggregatedSignatureOutGoingOperations())
 

--- a/consensus/spos/bls/v2/subroundEndRound_test.go
+++ b/consensus/spos/bls/v2/subroundEndRound_test.go
@@ -713,7 +713,7 @@ func TestSubroundEndRound_CreateAndBroadcastProofShouldBeCalled(t *testing.T) {
 
 	extraAggSig := []byte("extraAggSig")
 	extraAggSigs := map[string][]byte{
-		block.OutGoingMbTx.String():                 extraAggSig,
+		block.OutGoingMbDeposit.String():            extraAggSig,
 		block.OutGoingMbChangeValidatorSet.String(): nil,
 	}
 
@@ -724,7 +724,7 @@ func TestSubroundEndRound_CreateAndBroadcastProofShouldBeCalled(t *testing.T) {
 	messenger := &consensusMocks.BroadcastMessengerMock{
 		BroadcastEquivalentProofCalled: func(proof data.HeaderProofHandler, pkBytes []byte) error {
 			require.Equal(t, map[string]data.ExtraSignatureDataHandler{
-				block.OutGoingMbTx.String(): &block.ExtraSignatureData{
+				block.OutGoingMbDeposit.String(): &block.ExtraSignatureData{
 					AggregatedSignature: extraAggSig,
 					LeaderSignature:     leaderExtraSig,
 				},
@@ -758,7 +758,7 @@ func TestSubroundEndRound_CreateAndBroadcastProofShouldBeCalled(t *testing.T) {
 		GetSubRoundEndExtraSignersHolderCalled: func() bls.SubRoundEndExtraSignersHolder {
 			return &subRounds.SubRoundEndExtraSignersHolderMock{
 				GetLeaderExtraSigCalled: func(header data.HeaderHandler, id string) ([]byte, error) {
-					require.Equal(t, block.OutGoingMbTx.String(), id)
+					require.Equal(t, block.OutGoingMbDeposit.String(), id)
 					return leaderExtraSig, nil
 				},
 			}

--- a/consensus/spos/extraSigners/sovereignSubRoundEndExtraSigner_test.go
+++ b/consensus/spos/extraSigners/sovereignSubRoundEndExtraSigner_test.go
@@ -19,13 +19,13 @@ func TestNewSovereignSubRoundEndOutGoingTxData(t *testing.T) {
 	t.Parallel()
 
 	t.Run("nil signing handler, should return error", func(t *testing.T) {
-		sovSigHandler, err := NewSovereignSubRoundEndExtraSigner(nil, block.OutGoingMbTx, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
+		sovSigHandler, err := NewSovereignSubRoundEndExtraSigner(nil, block.OutGoingMbDeposit, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
 		require.Equal(t, spos.ErrNilSigningHandler, err)
 		require.True(t, check.IfNil(sovSigHandler))
 	})
 
 	t.Run("should work", func(t *testing.T) {
-		sovSigHandler, err := NewSovereignSubRoundEndExtraSigner(&cnsTest.SigningHandlerStub{}, block.OutGoingMbTx, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
+		sovSigHandler, err := NewSovereignSubRoundEndExtraSigner(&cnsTest.SigningHandlerStub{}, block.OutGoingMbDeposit, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
 		require.Nil(t, err)
 		require.False(t, sovSigHandler.IsInterfaceNil())
 	})
@@ -59,7 +59,7 @@ func TestSovereignSubRoundEndOutGoingTxData_VerifyAggregatedSignatures(t *testin
 			return nil
 		},
 	}
-	sovSigHandler, _ := NewSovereignSubRoundEndExtraSigner(signingHandler, block.OutGoingMbTx, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
+	sovSigHandler, _ := NewSovereignSubRoundEndExtraSigner(signingHandler, block.OutGoingMbDeposit, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
 
 	t.Run("invalid header type, should return error", func(t *testing.T) {
 		err := sovSigHandler.VerifyAggregatedSignatures(expectedBitMap, sovHdr.Header)
@@ -117,7 +117,7 @@ func TestSovereignSubRoundEndOutGoingTxData_AggregateSignatures(t *testing.T) {
 			return nil
 		},
 	}
-	sovSigHandler, _ := NewSovereignSubRoundEndExtraSigner(signingHandler, block.OutGoingMbTx, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
+	sovSigHandler, _ := NewSovereignSubRoundEndExtraSigner(signingHandler, block.OutGoingMbDeposit, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
 	result, err := sovSigHandler.AggregateAndSetSignatures(expectedBitMap, sovHdr)
 	require.Nil(t, err)
 	require.Equal(t, aggregatedSig, result)
@@ -139,7 +139,7 @@ func TestSovereignSubRoundEndOutGoingTxData_SeAggregatedSignatureInHeader(t *tes
 		},
 	}
 
-	sovSigHandler, _ := NewSovereignSubRoundEndExtraSigner(&cnsTest.SigningHandlerStub{}, block.OutGoingMbTx, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
+	sovSigHandler, _ := NewSovereignSubRoundEndExtraSigner(&cnsTest.SigningHandlerStub{}, block.OutGoingMbDeposit, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
 
 	t.Run("invalid header type, should return error", func(t *testing.T) {
 		err := sovSigHandler.SetAggregatedSignatureInHeader(sovHdr.Header, aggregatedSig)
@@ -202,7 +202,7 @@ func TestSovereignSubRoundEndOutGoingTxData_SignAndSetLeaderSignature(t *testing
 		},
 	}
 
-	sovSigHandler, _ := NewSovereignSubRoundEndExtraSigner(signingHandler, block.OutGoingMbTx, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
+	sovSigHandler, _ := NewSovereignSubRoundEndExtraSigner(signingHandler, block.OutGoingMbDeposit, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
 
 	t.Run("invalid header type, should return error", func(t *testing.T) {
 		err := sovSigHandler.SignAndSetLeaderSignature(sovHdr.Header, expectedLeaderPubKey)
@@ -270,7 +270,7 @@ func TestSovereignSubRoundEndOutGoingTxData_SignAndSetLeaderSignatureInAndromeda
 
 	sovSigHandler, _ := NewSovereignSubRoundEndExtraSigner(
 		signingHandler,
-		block.OutGoingMbTx,
+		block.OutGoingMbDeposit,
 		enableEpochsHandlerMock.NewEnableEpochsHandlerStub(common.AndromedaFlag),
 	)
 
@@ -299,7 +299,7 @@ func TestSovereignSubRoundEndOutGoingTxData_HaveConsensusHeaderWithFullInfo(t *t
 	leaderSig := []byte("leaderSig")
 	cnsMsg := &consensus.Message{
 		ExtraSignatures: map[string]*consensus.ExtraSignatureData{
-			block.OutGoingMbTx.String(): {
+			block.OutGoingMbDeposit.String(): {
 				AggregatedSignatureOutGoingTxData: aggregatedSig,
 				LeaderSignatureOutGoingTxData:     leaderSig,
 			},
@@ -319,7 +319,7 @@ func TestSovereignSubRoundEndOutGoingTxData_HaveConsensusHeaderWithFullInfo(t *t
 		},
 	}
 
-	sovSigHandler, _ := NewSovereignSubRoundEndExtraSigner(&cnsTest.SigningHandlerStub{}, block.OutGoingMbTx, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
+	sovSigHandler, _ := NewSovereignSubRoundEndExtraSigner(&cnsTest.SigningHandlerStub{}, block.OutGoingMbDeposit, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
 
 	t.Run("invalid header type, should return error", func(t *testing.T) {
 		err := sovSigHandler.SetConsensusDataInHeader(sovHdr.Header, cnsMsg)
@@ -375,7 +375,7 @@ func TestSovereignSubRoundEndOutGoingTxData_AddLeaderAndAggregatedSignatures(t *
 		},
 	}
 
-	sovSigHandler, _ := NewSovereignSubRoundEndExtraSigner(&cnsTest.SigningHandlerStub{}, block.OutGoingMbTx, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
+	sovSigHandler, _ := NewSovereignSubRoundEndExtraSigner(&cnsTest.SigningHandlerStub{}, block.OutGoingMbDeposit, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
 
 	t.Run("invalid header type, should return error", func(t *testing.T) {
 		err := sovSigHandler.AddLeaderAndAggregatedSignatures(sovHdr.Header, cnsMsg)
@@ -395,7 +395,7 @@ func TestSovereignSubRoundEndOutGoingTxData_AddLeaderAndAggregatedSignatures(t *
 		require.Nil(t, err)
 		require.Equal(t, &consensus.Message{
 			ExtraSignatures: map[string]*consensus.ExtraSignatureData{
-				block.OutGoingMbTx.String(): {
+				block.OutGoingMbDeposit.String(): {
 					AggregatedSignatureOutGoingTxData: aggregatedSig,
 					LeaderSignatureOutGoingTxData:     leaderSig,
 				},
@@ -406,6 +406,6 @@ func TestSovereignSubRoundEndOutGoingTxData_AddLeaderAndAggregatedSignatures(t *
 
 func TestSovereignSubRoundEndOutGoingTxData_Identifier(t *testing.T) {
 	t.Parallel()
-	sovSigHandler, _ := NewSovereignSubRoundEndExtraSigner(&cnsTest.SigningHandlerStub{}, block.OutGoingMbTx, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
-	require.Equal(t, block.OutGoingMbTx.String(), sovSigHandler.Identifier())
+	sovSigHandler, _ := NewSovereignSubRoundEndExtraSigner(&cnsTest.SigningHandlerStub{}, block.OutGoingMbDeposit, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
+	require.Equal(t, block.OutGoingMbDeposit.String(), sovSigHandler.Identifier())
 }

--- a/consensus/spos/extraSigners/sovereignSubRoundSignatureExtraSigner_test.go
+++ b/consensus/spos/extraSigners/sovereignSubRoundSignatureExtraSigner_test.go
@@ -17,13 +17,13 @@ func TestNewSovereignSubRoundSignatureOutGoingTxData(t *testing.T) {
 	t.Parallel()
 
 	t.Run("nil signing handler, should return error", func(t *testing.T) {
-		sovSigHandler, err := NewSovereignSubRoundSignatureExtraSigner(nil, block.OutGoingMbTx)
+		sovSigHandler, err := NewSovereignSubRoundSignatureExtraSigner(nil, block.OutGoingMbDeposit)
 		require.Equal(t, spos.ErrNilSigningHandler, err)
 		require.True(t, check.IfNil(sovSigHandler))
 	})
 
 	t.Run("should work", func(t *testing.T) {
-		sovSigHandler, err := NewSovereignSubRoundSignatureExtraSigner(&cnsTest.SigningHandlerStub{}, block.OutGoingMbTx)
+		sovSigHandler, err := NewSovereignSubRoundSignatureExtraSigner(&cnsTest.SigningHandlerStub{}, block.OutGoingMbDeposit)
 		require.Nil(t, err)
 		require.False(t, sovSigHandler.IsInterfaceNil())
 	})
@@ -60,7 +60,7 @@ func TestSovereignSubRoundSignatureOutGoingTxData_CreateSignatureShare(t *testin
 			return expectedSigShare, nil
 		},
 	}
-	sovSigHandler, _ := NewSovereignSubRoundSignatureExtraSigner(signingHandler, block.OutGoingMbTx)
+	sovSigHandler, _ := NewSovereignSubRoundSignatureExtraSigner(signingHandler, block.OutGoingMbDeposit)
 
 	t.Run("invalid header type, should return error", func(t *testing.T) {
 		sigShare, err := sovSigHandler.CreateSignatureShare(sovHdr.Header, selfIndex, selfPubKey)
@@ -92,7 +92,7 @@ func TestSovereignSubRoundSignatureOutGoingTxData_AddSigShareToConsensusMessage(
 		SignatureShare: []byte("sigShare"),
 	}
 
-	sovSigHandler, _ := NewSovereignSubRoundSignatureExtraSigner(&cnsTest.SigningHandlerStub{}, block.OutGoingMbTx)
+	sovSigHandler, _ := NewSovereignSubRoundSignatureExtraSigner(&cnsTest.SigningHandlerStub{}, block.OutGoingMbDeposit)
 
 	err := sovSigHandler.AddSigShareToConsensusMessage([]byte("sigShareOutGoingTxData"), nil)
 	require.Equal(t, errors.ErrNilConsensusMessage, err)
@@ -102,7 +102,7 @@ func TestSovereignSubRoundSignatureOutGoingTxData_AddSigShareToConsensusMessage(
 	require.Equal(t, &consensus.Message{
 		SignatureShare: []byte("sigShare"),
 		ExtraSignatures: map[string]*consensus.ExtraSignatureData{
-			block.OutGoingMbTx.String(): {
+			block.OutGoingMbDeposit.String(): {
 				SignatureShareOutGoingTxData: []byte("sigShareOutGoingTxData"),
 			},
 		},
@@ -115,7 +115,7 @@ func TestSovereignSubRoundSignatureOutGoingTxData_StoreSignatureShare(t *testing
 	cnsMsg := &consensus.Message{
 		SignatureShare: []byte("sigShare"),
 		ExtraSignatures: map[string]*consensus.ExtraSignatureData{
-			block.OutGoingMbTx.String(): {
+			block.OutGoingMbDeposit.String(): {
 				SignatureShareOutGoingTxData: []byte("sigShareOutGoingTxData"),
 			},
 		},
@@ -126,14 +126,14 @@ func TestSovereignSubRoundSignatureOutGoingTxData_StoreSignatureShare(t *testing
 	signHandler := &cnsTest.SigningHandlerStub{
 		StoreSignatureShareCalled: func(index uint16, sig []byte) error {
 			require.Equal(t, expectedIdx, index)
-			require.Equal(t, cnsMsg.ExtraSignatures[block.OutGoingMbTx.String()].SignatureShareOutGoingTxData, sig)
+			require.Equal(t, cnsMsg.ExtraSignatures[block.OutGoingMbDeposit.String()].SignatureShareOutGoingTxData, sig)
 
 			wasSigStored = true
 			return nil
 		},
 	}
 
-	sovSigHandler, _ := NewSovereignSubRoundSignatureExtraSigner(signHandler, block.OutGoingMbTx)
+	sovSigHandler, _ := NewSovereignSubRoundSignatureExtraSigner(signHandler, block.OutGoingMbDeposit)
 
 	err := sovSigHandler.StoreSignatureShare(expectedIdx, nil)
 	require.Equal(t, errors.ErrNilConsensusMessage, err)
@@ -146,6 +146,6 @@ func TestSovereignSubRoundSignatureOutGoingTxData_StoreSignatureShare(t *testing
 func TestSovereignSubRoundSignatureOutGoingTxData_Identifier(t *testing.T) {
 	t.Parallel()
 
-	sovSigHandler, _ := NewSovereignSubRoundSignatureExtraSigner(&cnsTest.SigningHandlerStub{}, block.OutGoingMbTx)
-	require.Equal(t, block.OutGoingMbTx.String(), sovSigHandler.Identifier())
+	sovSigHandler, _ := NewSovereignSubRoundSignatureExtraSigner(&cnsTest.SigningHandlerStub{}, block.OutGoingMbDeposit)
+	require.Equal(t, block.OutGoingMbDeposit.String(), sovSigHandler.Identifier())
 }

--- a/consensus/spos/extraSigners/sovereignSubRoundStartExtraSigner_test.go
+++ b/consensus/spos/extraSigners/sovereignSubRoundStartExtraSigner_test.go
@@ -15,13 +15,13 @@ func TestNewSovereignSubRoundStartOutGoingTxData(t *testing.T) {
 	t.Parallel()
 
 	t.Run("nil signing handler, should return error", func(t *testing.T) {
-		sovSigHandler, err := NewSovereignSubRoundStartExtraSigner(nil, block.OutGoingMbTx)
+		sovSigHandler, err := NewSovereignSubRoundStartExtraSigner(nil, block.OutGoingMbDeposit)
 		require.Equal(t, spos.ErrNilSigningHandler, err)
 		require.True(t, check.IfNil(sovSigHandler))
 	})
 
 	t.Run("should work", func(t *testing.T) {
-		sovSigHandler, err := NewSovereignSubRoundStartExtraSigner(&cnsTest.SigningHandlerStub{}, block.OutGoingMbTx)
+		sovSigHandler, err := NewSovereignSubRoundStartExtraSigner(&cnsTest.SigningHandlerStub{}, block.OutGoingMbDeposit)
 		require.Nil(t, err)
 		require.False(t, sovSigHandler.IsInterfaceNil())
 	})
@@ -40,7 +40,7 @@ func TestSovereignSubRoundStartOutGoingTxData_Reset(t *testing.T) {
 		},
 	}
 
-	sovSigHandler, _ := NewSovereignSubRoundStartExtraSigner(sigHandler, block.OutGoingMbTx)
+	sovSigHandler, _ := NewSovereignSubRoundStartExtraSigner(sigHandler, block.OutGoingMbDeposit)
 	err := sovSigHandler.Reset(expectedPubKeys)
 	require.Nil(t, err)
 	require.True(t, wasResetCalled)
@@ -49,6 +49,6 @@ func TestSovereignSubRoundStartOutGoingTxData_Reset(t *testing.T) {
 func TestSovereignSubRoundStartOutGoingTxData_Identifier(t *testing.T) {
 	t.Parallel()
 
-	sovSigHandler, _ := NewSovereignSubRoundStartExtraSigner(&cnsTest.SigningHandlerStub{}, block.OutGoingMbTx)
-	require.Equal(t, block.OutGoingMbTx.String(), sovSigHandler.Identifier())
+	sovSigHandler, _ := NewSovereignSubRoundStartExtraSigner(&cnsTest.SigningHandlerStub{}, block.OutGoingMbDeposit)
+	require.Equal(t, block.OutGoingMbDeposit.String(), sovSigHandler.Identifier())
 }

--- a/factory/runType/sovereignRunTypeComponents.go
+++ b/factory/runType/sovereignRunTypeComponents.go
@@ -289,8 +289,8 @@ func (rcf *sovereignRunTypeComponentsFactory) createOutGoingTxDataSigners() (bls
 	signRoundExtraSignersHolder := holders.NewSubRoundSignatureExtraSignersHolder()
 	endRoundExtraSignersHolder := holders.NewSubRoundEndExtraSignersHolder()
 
-	mbTypes := []dataBlock.OutGoingMBType{dataBlock.OutGoingMbDeposit, dataBlock.OutGoingMbChangeValidatorSet}
-	for _, mbType := range mbTypes {
+	for _, mbTypeValue := range dataBlock.OutGoingMBType_value {
+		mbType := dataBlock.OutGoingMBType(mbTypeValue)
 		extraSignerHandler := rcf.cryptoComponents.ConsensusSigningHandler().ShallowClone()
 
 		startRoundExtraSignerOutGoingTx, err := extraSigners.NewSovereignSubRoundStartExtraSigner(extraSignerHandler, mbType)

--- a/factory/runType/sovereignRunTypeComponents.go
+++ b/factory/runType/sovereignRunTypeComponents.go
@@ -289,7 +289,7 @@ func (rcf *sovereignRunTypeComponentsFactory) createOutGoingTxDataSigners() (bls
 	signRoundExtraSignersHolder := holders.NewSubRoundSignatureExtraSignersHolder()
 	endRoundExtraSignersHolder := holders.NewSubRoundEndExtraSignersHolder()
 
-	mbTypes := []dataBlock.OutGoingMBType{dataBlock.OutGoingMbTx, dataBlock.OutGoingMbChangeValidatorSet}
+	mbTypes := []dataBlock.OutGoingMBType{dataBlock.OutGoingMbDeposit, dataBlock.OutGoingMbChangeValidatorSet}
 	for _, mbType := range mbTypes {
 		extraSignerHandler := rcf.cryptoComponents.ConsensusSigningHandler().ShallowClone()
 

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 )
 
 require (
-	github.com/multiversx/mx-chain-sovereign-bridge-go v0.0.0-20250610105734-30b3338debcf
+	github.com/multiversx/mx-chain-sovereign-bridge-go v0.0.0-20250910122606-9cd08a686551
 	github.com/multiversx/mx-chain-sovereign-notifier-go v0.0.0-20250812062019-4c4f98dfb7c4
 	github.com/multiversx/mx-sdk-abi-go v0.3.0
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250218202821-56aae31c358a // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/multiversx/mx-chain-go
 
 replace (
-	github.com/multiversx/mx-chain-core-go => github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20250723113752-fe54477ddd7d
+	github.com/multiversx/mx-chain-core-go => github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20250909112243-f8ad1a2c5594
 	github.com/multiversx/mx-chain-es-indexer-go => github.com/multiversx/mx-chain-es-indexer-sovereign-go v1.7.17-0.20250715151725-0c18a314d0ea
 	github.com/multiversx/mx-chain-vm-common-go => github.com/multiversx/mx-chain-vm-common-sovereign-go v1.5.17-0.20250715144941-88820f3a7c28
 )

--- a/go.sum
+++ b/go.sum
@@ -405,8 +405,8 @@ github.com/multiversx/concurrent-map v0.1.4 h1:hdnbM8VE4b0KYJaGY5yJS2aNIW9TFFsUY
 github.com/multiversx/concurrent-map v0.1.4/go.mod h1:8cWFRJDOrWHOTNSqgYCUvwT7c7eFQ4U2vKMOp4A/9+o=
 github.com/multiversx/mx-chain-communication-go v1.3.0 h1:ziNM1dRuiR/7al2L/jGEA/a/hjurtJ/HEqgazHNt9P8=
 github.com/multiversx/mx-chain-communication-go v1.3.0/go.mod h1:gDVWn6zUW6aCN1YOm/FbbT5MUmhgn/L1Rmpl8EoH3Yg=
-github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20250723113752-fe54477ddd7d h1:GY+9/36cv/8aWTnBCcJKW0a/Xv9DydNuTz/3d0Fr8gA=
-github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20250723113752-fe54477ddd7d/go.mod h1:cJw3+5HfcHb5uIf3f/0cjYBXq6jumM3TNeQAY8UQFF0=
+github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20250909112243-f8ad1a2c5594 h1:E3gBrupBJb3S1angsgq1h+ZoM2Svnn8xkEmQC+WEF/0=
+github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20250909112243-f8ad1a2c5594/go.mod h1:cJw3+5HfcHb5uIf3f/0cjYBXq6jumM3TNeQAY8UQFF0=
 github.com/multiversx/mx-chain-crypto-go v1.3.0 h1:0eK2bkDOMi8VbSPrB1/vGJSYT81IBtfL4zw+C4sWe/k=
 github.com/multiversx/mx-chain-crypto-go v1.3.0/go.mod h1:nPIkxxzyTP8IquWKds+22Q2OJ9W7LtusC7cAosz7ojM=
 github.com/multiversx/mx-chain-es-indexer-sovereign-go v1.7.17-0.20250715151725-0c18a314d0ea h1:7h+IaMocTIwcJPqgQdAITL4UYaY+ZllfC9dldMrkbXk=

--- a/go.sum
+++ b/go.sum
@@ -415,8 +415,8 @@ github.com/multiversx/mx-chain-logger-go v1.1.0 h1:97x84A6L4RfCa6YOx1HpAFxZp1cf/
 github.com/multiversx/mx-chain-logger-go v1.1.0/go.mod h1:K9XgiohLwOsNACETMNL0LItJMREuEvTH6NsoXWXWg7g=
 github.com/multiversx/mx-chain-scenario-go v1.6.0 h1:cwDFuS1pSc4YXnfiKKDTEb+QDY4fulPQaiRgIebnKxI=
 github.com/multiversx/mx-chain-scenario-go v1.6.0/go.mod h1:GrSYu1SnMvsIm9djUz1X13224HcvdY6Nb5KHNT3xZPA=
-github.com/multiversx/mx-chain-sovereign-bridge-go v0.0.0-20250610105734-30b3338debcf h1:fv+vBuv7fhyDaxkY2q0scq0WWAPBCt9bgvNjStbNl4w=
-github.com/multiversx/mx-chain-sovereign-bridge-go v0.0.0-20250610105734-30b3338debcf/go.mod h1:1B4Be7y8OVK8cn3h/7nX5Q15QoGlqUEaL3UZJuhv16o=
+github.com/multiversx/mx-chain-sovereign-bridge-go v0.0.0-20250910122606-9cd08a686551 h1:fnnQtu3OEoIg3FJWXKdb2WfsmKinIV0fQn75UJenaCk=
+github.com/multiversx/mx-chain-sovereign-bridge-go v0.0.0-20250910122606-9cd08a686551/go.mod h1:+5OgkQVWyV2Jg7mlUa3FpmLQNhT3TzZ6pKr8VoCnprk=
 github.com/multiversx/mx-chain-sovereign-notifier-go v0.0.0-20250812062019-4c4f98dfb7c4 h1:bbxLhhbm9mJU0mK0sHO+cLeh551hkA/F/pQ4qwW9t3s=
 github.com/multiversx/mx-chain-sovereign-notifier-go v0.0.0-20250812062019-4c4f98dfb7c4/go.mod h1:iiDPVoM3Qks7QCuBM4l822WjBPqZxBHfRX9kE6ckYvw=
 github.com/multiversx/mx-chain-storage-go v1.1.0 h1:M1Y9DqMrJ62s7Zw31+cyuqsnPIvlG4jLBJl5WzeZLe8=

--- a/process/block/baseProcess_test.go
+++ b/process/block/baseProcess_test.go
@@ -3416,7 +3416,7 @@ func TestBaseProcessor_DisplayHeader(t *testing.T) {
 		require.Equal(t, 23, len(lines))
 
 		proof.ExtraSignatures = map[string]*block.ExtraSignatureData{
-			block.OutGoingMbTx.String(): {
+			block.OutGoingMbDeposit.String(): {
 				AggregatedSignature: []byte("aggSig1"),
 				LeaderSignature:     []byte("leaderSig1"),
 			},

--- a/process/block/displayBlock_test.go
+++ b/process/block/displayBlock_test.go
@@ -136,7 +136,7 @@ func TestDisplayBlock_DisplaySovereignChainHeader(t *testing.T) {
 
 	extendedShardHeaderHashes := [][]byte{[]byte("hash1"), []byte("hash2"), []byte("hash3")}
 	outGoingMbHeader1 := &block.OutGoingMiniBlockHeader{
-		Type:                                  block.OutGoingMbTx,
+		Type:                                  block.OutGoingMbDeposit,
 		Hash:                                  []byte("outGoingTxDataHash1"),
 		OutGoingOperationsHash:                []byte("outGoingOperationsHash1"),
 		AggregatedSignatureOutGoingOperations: []byte("aggregatedSig1"),

--- a/process/block/sovereign/dto/dto.go
+++ b/process/block/sovereign/dto/dto.go
@@ -20,4 +20,5 @@ type RegisteredBlsKey struct {
 	ID    []byte
 	Key   []byte
 	Owner []byte
+	Nonce uint64
 }

--- a/process/block/sovereign/interface.go
+++ b/process/block/sovereign/interface.go
@@ -2,6 +2,7 @@ package sovereign
 
 import (
 	"github.com/multiversx/mx-chain-core-go/data"
+	"github.com/multiversx/mx-chain-core-go/data/block"
 	"github.com/multiversx/mx-chain-core-go/data/sovereign"
 	"github.com/multiversx/mx-chain-go/process/block/sovereign/dto"
 )
@@ -9,7 +10,7 @@ import (
 // OutgoingOperationsFormatter collects relevant outgoing events for bridge from the logs and creates outgoing data
 // that needs to be signed by validators to bridge tokens
 type OutgoingOperationsFormatter interface {
-	CreateOutgoingTxsData(logs []*data.LogData) ([][]byte, error)
+	CreateOutgoingTxsData(logs []*data.LogData) (map[block.OutGoingMBType][][]byte, error)
 	CreateOutGoingChangeValidatorData(pubKeys []string, epoch uint32) ([]byte, error)
 	IsInterfaceNil() bool
 }

--- a/process/block/sovereign/operationFormatters/registerValidatorOpFormatter.go
+++ b/process/block/sovereign/operationFormatters/registerValidatorOpFormatter.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/multiversx/mx-chain-core-go/core/check"
 	"github.com/multiversx/mx-chain-core-go/data"
+	"github.com/multiversx/mx-chain-go/common"
 	errMx "github.com/multiversx/mx-chain-go/errors"
 	"github.com/multiversx/mx-chain-go/process"
 	"github.com/multiversx/mx-chain-go/process/block/sovereign/dto"
@@ -14,9 +15,10 @@ import (
 )
 
 const (
-	numExpectedTopicsInRegisterNewValidator = 2
-	topicIdxBlsKey                          = 0
-	topicIdxOwner                           = 1
+	numExpectedTopicsInRegisterValidator = 3
+	topicIdxBlsKey                       = 0
+	topicIdxOwner                        = 1
+	topicIdxNonce                        = 2
 )
 
 type registerValidatorOpFormatter struct {
@@ -45,8 +47,8 @@ func NewRegisterValidatorOpFormatter(
 // CreateOperationData creates a register/unregister new validator operation data
 func (op *registerValidatorOpFormatter) CreateOperationData(event data.EventHandler) ([]byte, error) {
 	numTopics := len(event.GetTopics())
-	if numTopics != numExpectedTopicsInRegisterNewValidator {
-		return nil, fmt.Errorf("%w, expected: %d, received: %d", errInvalidNumTopicsInRegisterValidator, numExpectedTopicsInRegisterNewValidator, numTopics)
+	if numTopics != numExpectedTopicsInRegisterValidator {
+		return nil, fmt.Errorf("%w, expected: %d, received: %d", errInvalidNumTopicsInRegisterValidator, numExpectedTopicsInRegisterValidator, numTopics)
 	}
 
 	if !bytes.Equal(event.GetAddress(), vm.StakingSCAddress) {
@@ -58,10 +60,16 @@ func (op *registerValidatorOpFormatter) CreateOperationData(event data.EventHand
 		return nil, err
 	}
 
+	nonce, err := common.ByteSliceToUint64(event.GetTopics()[topicIdxNonce])
+	if err != nil {
+		return nil, err
+	}
+
 	return op.dataCodec.SerializeNewlyRegisteredKey(dto.RegisteredBlsKey{
 		ID:    peerAcc.GetMainChainID(),
 		Key:   peerAcc.GetBLSPublicKey(),
 		Owner: event.GetTopics()[topicIdxOwner],
+		Nonce: nonce,
 	})
 }
 

--- a/process/block/sovereign/operationFormatters/registerValidatorOpFormatter_test.go
+++ b/process/block/sovereign/operationFormatters/registerValidatorOpFormatter_test.go
@@ -2,6 +2,7 @@ package operationFormatters
 
 import (
 	"errors"
+	"math/big"
 	"testing"
 
 	"github.com/multiversx/mx-chain-core-go/data/transaction"
@@ -50,12 +51,14 @@ func TestRegisterNewValidatorOpFormatter_CreateOperationData(t *testing.T) {
 	}
 
 	serializedData := []byte("serializedData")
+	nonce := uint64(4)
 	dataCodec := &sovereign.DataCodecMock{
 		SerializeNewlyRegisteredKeyCalled: func(keyData dto.RegisteredBlsKey) ([]byte, error) {
 			require.Equal(t, dto.RegisteredBlsKey{
 				ID:    mainChainID,
 				Key:   blsKey,
 				Owner: ownerAddress,
+				Nonce: nonce,
 			}, keyData)
 
 			return serializedData, nil
@@ -64,7 +67,7 @@ func TestRegisterNewValidatorOpFormatter_CreateOperationData(t *testing.T) {
 
 	event := &transaction.Event{
 		Address: vm.StakingSCAddress,
-		Topics:  [][]byte{blsKey, ownerAddress},
+		Topics:  [][]byte{blsKey, ownerAddress, big.NewInt(int64(nonce)).Bytes()},
 	}
 	opFormatter, _ := NewRegisterValidatorOpFormatter(peerAccountsDB, dataCodec)
 	res, err := opFormatter.CreateOperationData(event)
@@ -89,7 +92,7 @@ func TestRegisterNewValidatorOpFormatter_CreateOperationDataErrorCases(t *testin
 	t.Run("invalid event address", func(t *testing.T) {
 		event := &transaction.Event{
 			Address: vm.ValidatorSCAddress,
-			Topics:  [][]byte{[]byte("blsKey"), []byte("owner")},
+			Topics:  [][]byte{[]byte("blsKey"), []byte("owner"), []byte("nonce")},
 		}
 
 		opFormatter, _ := NewRegisterValidatorOpFormatter(&state.AccountsStub{}, &sovereign.DataCodecMock{})
@@ -100,7 +103,7 @@ func TestRegisterNewValidatorOpFormatter_CreateOperationDataErrorCases(t *testin
 	t.Run("cannot load account", func(t *testing.T) {
 		event := &transaction.Event{
 			Address: vm.StakingSCAddress,
-			Topics:  [][]byte{[]byte("blsKey"), []byte("owner")},
+			Topics:  [][]byte{[]byte("blsKey"), []byte("owner"), []byte("nonce")},
 		}
 
 		expectedErr := errors.New("load account fails")

--- a/process/block/sovereign/outgoingOperations.go
+++ b/process/block/sovereign/outgoingOperations.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/multiversx/mx-chain-core-go/core/check"
 	"github.com/multiversx/mx-chain-core-go/data"
+	"github.com/multiversx/mx-chain-core-go/data/block"
 	"github.com/multiversx/mx-chain-core-go/data/sovereign"
 	"github.com/multiversx/mx-chain-go/process"
 	"github.com/multiversx/mx-chain-go/process/block/sovereign/operationFormatters"
@@ -16,7 +17,11 @@ import (
 	"github.com/multiversx/mx-chain-go/state"
 )
 
-type createOpFormatterHandler func(args ArgsOutgoingOperations) (OperationFormatter, error)
+type opFormatterData struct {
+	handler OperationFormatter
+	mbType  block.OutGoingMBType
+}
+type createOpFormatterHandler func(args ArgsOutgoingOperations) (OperationFormatter, block.OutGoingMBType, error)
 
 const (
 	topicIDDeposit          = "deposit"
@@ -46,7 +51,7 @@ type outgoingOperations struct {
 	topicsChecker    TopicsCheckerHandler
 	peerAccountsDB   state.AccountsAdapter
 
-	opFormatters map[string]OperationFormatter
+	opFormatters map[string]opFormatterData
 }
 
 // TODO: We should create a common base functionality from this component. Similar behavior is also found in
@@ -134,8 +139,8 @@ func checkEmptyAddresses(addresses map[string]string) error {
 	return nil
 }
 
-func createOpFormatterHandlers(subscribedEvents map[string]struct{}, args ArgsOutgoingOperations) (map[string]OperationFormatter, error) {
-	handlers := make(map[string]OperationFormatter)
+func createOpFormatterHandlers(subscribedEvents map[string]struct{}, args ArgsOutgoingOperations) (map[string]opFormatterData, error) {
+	handlers := make(map[string]opFormatterData)
 
 	blsKeyOpFormatter, err := operationFormatters.NewRegisterValidatorOpFormatter(args.PeerAccountsDB, args.DataCodec)
 	if err != nil {
@@ -143,17 +148,19 @@ func createOpFormatterHandlers(subscribedEvents map[string]struct{}, args ArgsOu
 	}
 
 	availableHandlers := map[string]createOpFormatterHandler{
-		topicIDDeposit: func(args ArgsOutgoingOperations) (OperationFormatter, error) {
-			return operationFormatters.NewDepositOpFormatter(args.DataCodec, args.TopicsChecker)
+		topicIDDeposit: func(args ArgsOutgoingOperations) (OperationFormatter, block.OutGoingMBType, error) {
+			opFormatter, err := operationFormatters.NewDepositOpFormatter(args.DataCodec, args.TopicsChecker)
+			return opFormatter, block.OutGoingMbDeposit, err
 		},
-		topicIDRegisterToken: func(args ArgsOutgoingOperations) (OperationFormatter, error) {
-			return operationFormatters.NewRegisterTokenOpFormatter(args.DataCodec)
+		topicIDRegisterToken: func(args ArgsOutgoingOperations) (OperationFormatter, block.OutGoingMBType, error) {
+			opFormatter, err := operationFormatters.NewRegisterTokenOpFormatter(args.DataCodec)
+			return opFormatter, block.OutGoingMBRegisterToken, err
 		},
-		topicIDRegisterBlsKey: func(args ArgsOutgoingOperations) (OperationFormatter, error) {
-			return blsKeyOpFormatter, nil
+		topicIDRegisterBlsKey: func(args ArgsOutgoingOperations) (OperationFormatter, block.OutGoingMBType, error) {
+			return blsKeyOpFormatter, block.OutGoingMBRegisterBlsKey, nil
 		},
-		topicIDUnRegisterBlsKey: func(args ArgsOutgoingOperations) (OperationFormatter, error) {
-			return blsKeyOpFormatter, nil
+		topicIDUnRegisterBlsKey: func(args ArgsOutgoingOperations) (OperationFormatter, block.OutGoingMBType, error) {
+			return blsKeyOpFormatter, block.OutGoingMBUnRegisterBlsKey, nil
 		},
 	}
 
@@ -180,7 +187,7 @@ func createOpFormatterHandlers(subscribedEvents map[string]struct{}, args ArgsOu
 func addHandlerIfSubscribed(
 	id string,
 	subscribedEvents map[string]struct{},
-	allHandlers map[string]OperationFormatter,
+	allHandlers map[string]opFormatterData,
 	createOpFormatterHandlerFunc createOpFormatterHandler,
 	args ArgsOutgoingOperations,
 ) error {
@@ -189,27 +196,31 @@ func addHandlerIfSubscribed(
 		return nil
 	}
 
-	opHandler, err := createOpFormatterHandlerFunc(args)
+	opHandler, mbType, err := createOpFormatterHandlerFunc(args)
 	if err != nil {
 		return err
 	}
 
-	allHandlers[id] = opHandler
+	allHandlers[id] = opFormatterData{
+		handler: opHandler,
+		mbType:  mbType,
+	}
+
 	delete(subscribedEvents, id)
 	return nil
 }
 
 // CreateOutgoingTxsData collects relevant outgoing events(based on subscribed addresses and topics) for bridge from the
 // logs and creates outgoing data that needs to be signed by validators to bridge tokens
-func (op *outgoingOperations) CreateOutgoingTxsData(logs []*data.LogData) ([][]byte, error) {
+func (op *outgoingOperations) CreateOutgoingTxsData(logs []*data.LogData) (map[block.OutGoingMBType][][]byte, error) {
 	outgoingEvents := op.createOutgoingEvents(logs)
 	if len(outgoingEvents) == 0 {
-		return make([][]byte, 0), nil
+		return make(map[block.OutGoingMBType][][]byte), nil
 	}
 
-	txsData := make([][]byte, 0)
+	txsData := make(map[block.OutGoingMBType][][]byte)
 	for i, event := range outgoingEvents {
-		operation, err := op.getOperationData(event)
+		operation, mbType, err := op.getOperationData(event)
 		if err != nil {
 			log.Error("outgoingOperations.CreateOutgoingTxsData error",
 				"tx hash", logs[i].TxHash,
@@ -219,7 +230,7 @@ func (op *outgoingOperations) CreateOutgoingTxsData(logs []*data.LogData) ([][]b
 			return nil, err
 		}
 
-		txsData = append(txsData, operation)
+		txsData[mbType] = append(txsData[mbType], operation)
 	}
 
 	// TODO: Check gas limit here and split tx data in multiple batches if required
@@ -271,14 +282,15 @@ func (op *outgoingOperations) isSubscribed(event data.EventHandler, txHash strin
 	return false
 }
 
-func (op *outgoingOperations) getOperationData(event data.EventHandler) ([]byte, error) {
+func (op *outgoingOperations) getOperationData(event data.EventHandler) ([]byte, block.OutGoingMBType, error) {
 	opFormatter, found := op.opFormatters[string(event.GetIdentifier())]
 	if !found {
 		log.Error("outgoingOperations.getOperationData: event not found", "event", string(event.GetIdentifier()))
-		return nil, errEventIDNotFound
+		return nil, block.OutGoingMBType(0), errEventIDNotFound
 	}
 
-	return opFormatter.CreateOperationData(event)
+	opData, err := opFormatter.handler.CreateOperationData(event)
+	return opData, opFormatter.mbType, err
 }
 
 // CreateOutGoingChangeValidatorData will create the necessary outgoing data for validator set change

--- a/process/block/sovereign/outgoingOperations_test.go
+++ b/process/block/sovereign/outgoingOperations_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/data"
+	"github.com/multiversx/mx-chain-core-go/data/block"
 	"github.com/multiversx/mx-chain-core-go/data/sovereign"
 	transactionData "github.com/multiversx/mx-chain-core-go/data/transaction"
 	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
@@ -21,7 +22,7 @@ import (
 func createEvents() []SubscribedEvent {
 	return []SubscribedEvent{
 		{
-			Identifier: []byte("deposit"),
+			Identifier: []byte(topicIDDeposit),
 			Addresses: map[string]string{
 				"decodedAddr": "encodedAddr",
 			},
@@ -109,7 +110,7 @@ func TestNewOutgoingOperationsFormatter(t *testing.T) {
 func createArgsOutGoingOpsFormatterWithEvents() ArgsOutgoingOperations {
 	events := []SubscribedEvent{
 		{
-			Identifier: []byte("deposit"),
+			Identifier: []byte(topicIDDeposit),
 			Addresses: map[string]string{
 				"addr1": "addr1",
 				"addr2": "addr2",
@@ -195,7 +196,7 @@ func TestOutgoingOperations_CreateOutgoingTxsDataErrorCases(t *testing.T) {
 				Events: []*transactionData.Event{
 					{
 						Address:    []byte("addr1"),
-						Identifier: []byte("deposit"),
+						Identifier: []byte(topicIDDeposit),
 						Topics:     [][]byte{[]byte("topic1"), []byte("topic1"), []byte("topic1"), []byte("topic1"), []byte("topic1")},
 						Data:       []byte("data"),
 					},
@@ -287,12 +288,12 @@ func TestOutgoingOperations_CreateOutgoingTxData(t *testing.T) {
 	addr1 := []byte("addr1")
 	addr2 := []byte("addr2")
 
-	identifier1 := []byte("deposit")
+	identifier1 := []byte(topicIDDeposit)
 	identifier2 := []byte("send")
 
 	tokenData1 := []byte("tokenData1")
 	topic1 := [][]byte{
-		[]byte("deposit"),
+		[]byte(topicIDDeposit),
 		[]byte("rcv1"),
 		[]byte("token1"),
 		[]byte("nonce1"),
@@ -380,16 +381,18 @@ func TestOutgoingOperations_CreateOutgoingTxData(t *testing.T) {
 
 	outgoingTxData, err := opFormatter.CreateOutgoingTxsData(logs)
 	require.Nil(t, err)
-	require.Equal(t, [][]byte{operationBytes}, outgoingTxData)
+	require.Equal(t, map[block.OutGoingMBType][][]byte{
+		block.OutGoingMbDeposit: {operationBytes},
+	}, outgoingTxData)
 }
 
 func TestOutgoingOperations_CreateOutgoingTxScCall(t *testing.T) {
 	t.Parallel()
 
 	addr := []byte("addr")
-	identifier := []byte("deposit")
+	identifier := []byte(topicIDDeposit)
 	topics := [][]byte{
-		[]byte("deposit"),
+		[]byte(topicIDDeposit),
 		[]byte("receiver"),
 	}
 	eventData := []byte("eventData")
@@ -459,7 +462,9 @@ func TestOutgoingOperations_CreateOutgoingTxScCall(t *testing.T) {
 
 	outgoingTxData, err := opFormatter.CreateOutgoingTxsData(logs)
 	require.Nil(t, err)
-	require.Equal(t, [][]byte{operationBytes}, outgoingTxData)
+	require.Equal(t, map[block.OutGoingMBType][][]byte{
+		block.OutGoingMbDeposit: {operationBytes},
+	}, outgoingTxData)
 }
 
 func TestOutgoingOperations_CreateOutGoingChangeValidatorData(t *testing.T) {

--- a/process/block/sovereignChainBlock.go
+++ b/process/block/sovereignChainBlock.go
@@ -1635,7 +1635,7 @@ func (scbp *sovereignChainBlockProcessor) createAndSetOutGoingMiniBlockTxs(heade
 		headerHandler,
 		outGoingOperations,
 		blockBody,
-		block.OutGoingMbTx,
+		block.OutGoingMbDeposit,
 	)
 }
 

--- a/process/block/sovereignChainBlock.go
+++ b/process/block/sovereignChainBlock.go
@@ -1631,12 +1631,19 @@ func (scbp *sovereignChainBlockProcessor) createAndSetOutGoingMiniBlockTxs(heade
 		return err
 	}
 
-	return scbp.createAndSetOutGoingMiniBlock(
-		headerHandler,
-		outGoingOperations,
-		blockBody,
-		block.OutGoingMbDeposit,
-	)
+	for mbType, outGoingOps := range outGoingOperations {
+		err = scbp.createAndSetOutGoingMiniBlock(
+			headerHandler,
+			outGoingOps,
+			blockBody,
+			mbType,
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (scbp *sovereignChainBlockProcessor) createAndSetOutGoingMiniBlock(

--- a/process/block/sovereignChainBlock_test.go
+++ b/process/block/sovereignChainBlock_test.go
@@ -311,9 +311,11 @@ func TestSovereignChainBlockProcessor_createAndSetOutGoingMiniBlockTxs(t *testin
 	bridgeOpsHash := outgoingOpsHasher.Compute(string(append(bridgeOp1Hash, bridgeOp2Hash...)))
 
 	outgoingOperationsFormatter := &sovereign.OutgoingOperationsFormatterMock{
-		CreateOutgoingTxDataCalled: func(logs []*data.LogData) ([][]byte, error) {
+		CreateOutgoingTxDataCalled: func(logs []*data.LogData) (map[block.OutGoingMBType][][]byte, error) {
 			require.Equal(t, expectedLogs, logs)
-			return [][]byte{bridgeOp1, bridgeOp2}, nil
+			return map[block.OutGoingMBType][][]byte{
+					block.OutGoingMbDeposit: {bridgeOp1, bridgeOp2}},
+				nil
 		},
 	}
 

--- a/process/headerCheck/sovereignExtraHeaderSignatureVerifier_test.go
+++ b/process/headerCheck/sovereignExtraHeaderSignatureVerifier_test.go
@@ -99,7 +99,7 @@ func TestSovereignHeaderSigVerifier_getAggregatedSignature(t *testing.T) {
 	outGoingOpHash := []byte("outGoingOpHash")
 	outGoingAggregatedSig := []byte("aggregatedSig")
 	outGoingMBHeader := &block.OutGoingMiniBlockHeader{
-		Type:                                  block.OutGoingMbTx,
+		Type:                                  block.OutGoingMbDeposit,
 		OutGoingOperationsHash:                outGoingOpHash,
 		AggregatedSignatureOutGoingOperations: outGoingAggregatedSig,
 	}
@@ -135,7 +135,7 @@ func TestSovereignHeaderSigVerifier_getAggregatedSignature(t *testing.T) {
 		aggregatedSigFromProof := []byte("aggregatedSigFromProof")
 		proof := &block.HeaderProof{
 			ExtraSignatures: map[string]*block.ExtraSignatureData{
-				block.OutGoingMbTx.String(): {
+				block.OutGoingMbDeposit.String(): {
 					AggregatedSignature: aggregatedSigFromProof,
 				},
 			},
@@ -161,7 +161,7 @@ func TestSovereignHeaderSigVerifier_getLeaderSignedMessage(t *testing.T) {
 	outGoingOpHash := []byte("outGoingOpHash")
 	outGoingAggregatedSig := []byte("aggregatedSig")
 	outGoingMBHeader := &block.OutGoingMiniBlockHeader{
-		Type:                                  block.OutGoingMbTx,
+		Type:                                  block.OutGoingMbDeposit,
 		OutGoingOperationsHash:                outGoingOpHash,
 		AggregatedSignatureOutGoingOperations: outGoingAggregatedSig,
 	}

--- a/testscommon/sovereign/outgoingOperationsFormatterMock.go
+++ b/testscommon/sovereign/outgoingOperationsFormatterMock.go
@@ -1,20 +1,23 @@
 package sovereign
 
-import "github.com/multiversx/mx-chain-core-go/data"
+import (
+	"github.com/multiversx/mx-chain-core-go/data"
+	"github.com/multiversx/mx-chain-core-go/data/block"
+)
 
 // OutgoingOperationsFormatterMock -
 type OutgoingOperationsFormatterMock struct {
-	CreateOutgoingTxDataCalled              func(logs []*data.LogData) ([][]byte, error)
+	CreateOutgoingTxDataCalled              func(logs []*data.LogData) (map[block.OutGoingMBType][][]byte, error)
 	CreateOutGoingChangeValidatorDataCalled func(pubKeys []string, epoch uint32) ([]byte, error)
 }
 
 // CreateOutgoingTxsData -
-func (stub *OutgoingOperationsFormatterMock) CreateOutgoingTxsData(logs []*data.LogData) ([][]byte, error) {
+func (stub *OutgoingOperationsFormatterMock) CreateOutgoingTxsData(logs []*data.LogData) (map[block.OutGoingMBType][][]byte, error) {
 	if stub.CreateOutgoingTxDataCalled != nil {
 		return stub.CreateOutgoingTxDataCalled(logs)
 	}
 
-	return make([][]byte, 0), nil
+	return make(map[block.OutGoingMBType][][]byte), nil
 }
 
 // CreateOutGoingChangeValidatorData -

--- a/vm/systemSmartContracts/staking.go
+++ b/vm/systemSmartContracts/staking.go
@@ -580,14 +580,18 @@ func (s *stakingSC) activeStakingFor(stakingData *StakedDataV2_0) {
 
 func (s *stakingSC) processStake(blsKey []byte, registrationData *StakedDataV2_0, addFirst bool, newNode bool) error {
 	if s.enableEpochsHandler.IsFlagEnabled(common.StakingV4StartedFlag) {
-		s.addRegisterBlsKeyLogIfNeeded(blsKey, registrationData.OwnerAddress, newNode)
-		return s.processStakeV2(registrationData)
+		return s.processStakeV2(blsKey, registrationData, newNode)
 	}
 
 	return s.processStakeV1(blsKey, registrationData, addFirst)
 }
 
-func (s *stakingSC) addRegisterBlsKeyLogIfNeeded(blsKey []byte, owner []byte, newNode bool) {
+func (s *stakingSC) addRegisterBlsKeyLogIfNeeded(
+	blsKey []byte,
+	registrationData *StakedDataV2_0,
+	stakingConfig *StakingNodesConfig,
+	newNode bool,
+) {
 	if !newNode {
 		return
 	}
@@ -598,12 +602,18 @@ func (s *stakingSC) addRegisterBlsKeyLogIfNeeded(blsKey []byte, owner []byte, ne
 
 	s.eei.AddLogEntry(&vmcommon.LogEntry{
 		Identifier: []byte(idLogRegisterBlsKey),
-		Topics:     [][]byte{blsKey, owner},
-		Address:    vm.StakingSCAddress,
+		Topics: [][]byte{
+			blsKey,
+			registrationData.OwnerAddress,
+			big.NewInt(int64(registrationData.StakedNonce)).Bytes(),
+		},
+		Address: vm.StakingSCAddress,
 	})
+
+	registrationData.MainChainID = stakingConfig.LatestMainChainID
 }
 
-func (s *stakingSC) processStakeV2(registrationData *StakedDataV2_0) error {
+func (s *stakingSC) processStakeV2(blsKey []byte, registrationData *StakedDataV2_0, newNode bool) error {
 	if registrationData.Staked {
 		return nil
 	}
@@ -611,7 +621,7 @@ func (s *stakingSC) processStakeV2(registrationData *StakedDataV2_0) error {
 	registrationData.RegisterNonce = s.eei.BlockChainHook().CurrentNonce()
 	stakingConfig := s.addToStakedNodesAndMainChainID(1)
 	s.activeStakingFor(registrationData)
-	registrationData.MainChainID = stakingConfig.LatestMainChainID
+	s.addRegisterBlsKeyLogIfNeeded(blsKey, registrationData, stakingConfig, newNode)
 
 	return nil
 }
@@ -697,20 +707,24 @@ func (s *stakingSC) doUnStake(key []byte, registrationData *StakedDataV2_0) vmco
 		return vmcommon.UserError
 	}
 
-	s.addUnRegisterBlsKeyLogIfNeeded(key, registrationData.OwnerAddress)
+	s.addUnRegisterBlsKeyLogIfNeeded(key, registrationData)
 
 	return vmcommon.Ok
 }
 
-func (s *stakingSC) addUnRegisterBlsKeyLogIfNeeded(blsKey []byte, owner []byte) {
+func (s *stakingSC) addUnRegisterBlsKeyLogIfNeeded(blsKey []byte, registrationData *StakedDataV2_0) {
 	if !s.enableEpochsHandler.IsFlagEnabled(common.ConsensusModelSovereignFlag) {
 		return
 	}
 
 	s.eei.AddLogEntry(&vmcommon.LogEntry{
 		Identifier: []byte(idLogUnRegisterBlsKey),
-		Topics:     [][]byte{blsKey, owner},
-		Address:    vm.StakingSCAddress,
+		Topics: [][]byte{
+			blsKey,
+			registrationData.OwnerAddress,
+			big.NewInt(int64(registrationData.UnStakedNonce)).Bytes(),
+		},
+		Address: vm.StakingSCAddress,
 	})
 }
 


### PR DESCRIPTION
## Reasoning behind the pull request
- Include all outgoing op mb types from https://github.com/multiversx/mx-chain-core-sovereign-go/pull/21
  
## Proposed changes
- In `staking.go` we need to add the register/unregister event nonce (staked/unstaked nonce), otherwise outgoing ops will have the same hash
- Op formatter now returns a `map[blockType][]byte data`
- Further increase outGoingOps_test's complexity to cover multiple outgoing register/unregister mbs

## Testing procedure
- 
- 
- 

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
