### PR TITLE
Sorted outgoing data

### DIFF
--- a/cmd/sovereignnode/chainSimulator/process/sovereignBlockProcessor.go
+++ b/cmd/sovereignnode/chainSimulator/process/sovereignBlockProcessor.go
@@ -56,7 +56,7 @@ func (sbpf *sovereignBlockProcessor) ProcessHeaderProof(
 	}
 
 	for _, outGoingMb := range sovHdr.GetOutGoingMiniBlockHeaderHandlers() {
-		mbType := block.OutGoingMBType(outGoingMb.GetOutGoingMBTypeInt32()).String()
+		mbType := block.OutGoingMBType(outGoingMb.GetChainID()).String()
 		extraSigData, found := proof.GetExtraSignatureHandlers()[mbType]
 		if !found {
 			return fmt.Errorf("%w for type %s in ProcessHeaderProof", bls.ErrExtraSigShareDataNotFound, mbType)

--- a/cmd/sovereignnode/chainSimulator/tests/epochChange/epochChange_test.go
+++ b/cmd/sovereignnode/chainSimulator/tests/epochChange/epochChange_test.go
@@ -356,9 +356,9 @@ func checkOutGoingMiniBlockChangeValidatorSet(
 	require.Len(t, outGoingMBHdrs, 1)
 
 	bridgeData := nodeHandler.GetRunTypeComponents().OutGoingOperationsPoolHandler().Get(outGoingMBHdrs[0].GetOutGoingOperationsHash())
-	require.Equal(t, int32(block.OutGoingMbChangeValidatorSet), bridgeData.Type)
-	require.Equal(t, currentHeader.GetEpoch(), bridgeData.Epoch)
 	require.Len(t, bridgeData.OutGoingOperations, 1)
+	require.Equal(t, int32(block.OutGoingMbChangeValidatorSet), bridgeData.OutGoingOperations[0].Type)
+	require.Equal(t, currentHeader.GetEpoch(), bridgeData.Epoch)
 
 	outGoingBridgeDataValidators := &sovereignData.BridgeOutGoingDataValidatorSetChange{}
 	err := proto.Unmarshal(bridgeData.OutGoingOperations[0].Data, outGoingBridgeDataValidators)

--- a/cmd/sovereignnode/chainSimulator/tests/epochChange/outGoingOps_test.go
+++ b/cmd/sovereignnode/chainSimulator/tests/epochChange/outGoingOps_test.go
@@ -36,16 +36,20 @@ func getBridgeDataFromPrevBlock(
 	prevHdr, err := nodeHandler.GetDataComponents().Datapool().Headers().GetHeaderByHash(prevHdrHash)
 	require.Nil(t, err)
 
-	outGoingMBHdr := prevHdr.(data.SovereignChainHeaderHandler).GetOutGoingMiniBlockHeaderHandler(int32(mbType))
-	require.NotNil(t, outGoingMBHdr)
+	outGoingMBHdr := prevHdr.(data.SovereignChainHeaderHandler).GetOutGoingMiniBlockHeaderHandlers()
+	require.Len(t, outGoingMBHdr, 1)
 
-	bridgeData := nodeHandler.GetRunTypeComponents().OutGoingOperationsPoolHandler().Get(outGoingMBHdr.GetOutGoingOperationsHash())
-	require.NotEmpty(t, bridgeData.AggregatedSignature)
-	require.NotEmpty(t, bridgeData.LeaderSignature)
-	require.NotEmpty(t, bridgeData.PubKeysBitmap)
+	bridgeData := nodeHandler.GetRunTypeComponents().OutGoingOperationsPoolHandler().Get(outGoingMBHdr[0].GetOutGoingOperationsHash())
+	require.True(t, len(bridgeData.OutGoingOperations) >= 1)
+	for _, outGoingOp := range bridgeData.OutGoingOperations {
+		if outGoingOp.Type == int32(mbType) {
+			require.NotEmpty(t, bridgeData.AggregatedSignature)
+			require.NotEmpty(t, bridgeData.LeaderSignature)
+			require.NotEmpty(t, bridgeData.PubKeysBitmap)
+		}
+	}
 
 	return prevHdr.GetNonce(), bridgeData
-
 }
 
 func checkOutGoingMiniBlockRegisterValidator(
@@ -55,14 +59,18 @@ func checkOutGoingMiniBlockRegisterValidator(
 	latestMainChainID int,
 ) {
 	nonce, bridgeData := getBridgeDataFromPrevBlock(t, nodeHandler, block.OutGoingMBRegisterBlsKey)
-	require.Equal(t, int32(block.OutGoingMBRegisterBlsKey), bridgeData.Type)
-	require.Len(t, bridgeData.OutGoingOperations, numOperations)
 
 	blsKeys := make([][]byte, 0)
 	assignedMainChainIDs := make([][]byte, 0)
-
 	expectedMainChainIDs := make([][]byte, 0)
+	numOutGoingOpsRegisterBlsKey := 0
 	for _, op := range bridgeData.OutGoingOperations {
+		if op.Type != int32(block.OutGoingMBRegisterBlsKey) {
+			continue
+		}
+
+		numOutGoingOpsRegisterBlsKey++
+
 		registeredData := deserializeRegisteredBlsKeyData(t, nodeHandler, serializer, op.Data)
 		require.Equal(t, nonce, registeredData.Nonce)
 
@@ -72,6 +80,8 @@ func checkOutGoingMiniBlockRegisterValidator(
 		latestMainChainID++
 		expectedMainChainIDs = append(expectedMainChainIDs, big.NewInt(int64(latestMainChainID)).Bytes())
 	}
+
+	require.Equal(t, numOperations, numOutGoingOpsRegisterBlsKey)
 
 	auctionNodes := getAuctionListKeys(t, nodeHandler)
 	require.ElementsMatch(t, expectedMainChainIDs, assignedMainChainIDs)
@@ -87,13 +97,17 @@ func checkOutGoingMiniBlockUnRegisterValidator(
 	// StakeNodes func from staking/common.go generates one extra block after staking tx, so we need to get
 	// data from previous block
 	nonce, bridgeData := getBridgeDataFromPrevBlock(t, nodeHandler, block.OutGoingMBUnRegisterBlsKey)
-	require.Equal(t, int32(block.OutGoingMBUnRegisterBlsKey), bridgeData.Type)
-	require.Len(t, bridgeData.OutGoingOperations, len(expectedBlsKeys))
 
 	blsKeys := make([][]byte, 0)
 	assignedMainChainIDs := make([][]byte, 0)
-
+	numOutGoingOpsUnregisterBlsKey := 0
 	for _, op := range bridgeData.OutGoingOperations {
+		if op.Type != int32(block.OutGoingMBUnRegisterBlsKey) {
+			continue
+		}
+
+		numOutGoingOpsUnregisterBlsKey++
+
 		registeredData := deserializeRegisteredBlsKeyData(t, nodeHandler, serializer, op.Data)
 		require.Equal(t, nonce, registeredData.Nonce)
 
@@ -101,6 +115,7 @@ func checkOutGoingMiniBlockUnRegisterValidator(
 		assignedMainChainIDs = append(assignedMainChainIDs, registeredData.ID)
 	}
 
+	require.Equal(t, numOutGoingOpsUnregisterBlsKey, len(expectedBlsKeys))
 	require.ElementsMatch(t, expectedMainChainIDs, assignedMainChainIDs)
 	require.ElementsMatch(t, expectedBlsKeys, blsKeys)
 }

--- a/cmd/sovereignnode/chainSimulator/tests/epochChange/outGoingOps_test.go
+++ b/cmd/sovereignnode/chainSimulator/tests/epochChange/outGoingOps_test.go
@@ -30,7 +30,6 @@ var serializer, _ = abi.NewSerializer(abi.ArgsNewSerializer{PartsSeparator: "@"}
 func getBridgeDataFromPrevBlock(
 	t *testing.T,
 	nodeHandler process.NodeHandler,
-	mbType block.OutGoingMBType,
 ) (uint64, *sovereign.BridgeOutGoingData) {
 	prevHdrHash := nodeHandler.GetDataComponents().Blockchain().GetCurrentBlockHeader().GetPrevHash()
 	prevHdr, err := nodeHandler.GetDataComponents().Datapool().Headers().GetHeaderByHash(prevHdrHash)
@@ -54,7 +53,7 @@ func checkOutGoingMiniBlockRegisterValidator(
 	numOperations int,
 	latestMainChainID int,
 ) {
-	nonce, bridgeData := getBridgeDataFromPrevBlock(t, nodeHandler, block.OutGoingMBRegisterBlsKey)
+	nonce, bridgeData := getBridgeDataFromPrevBlock(t, nodeHandler)
 
 	blsKeys := make([][]byte, 0)
 	assignedMainChainIDs := make([][]byte, 0)
@@ -92,7 +91,7 @@ func checkOutGoingMiniBlockUnRegisterValidator(
 ) {
 	// StakeNodes func from staking/common.go generates one extra block after staking tx, so we need to get
 	// data from previous block
-	nonce, bridgeData := getBridgeDataFromPrevBlock(t, nodeHandler, block.OutGoingMBUnRegisterBlsKey)
+	nonce, bridgeData := getBridgeDataFromPrevBlock(t, nodeHandler)
 
 	blsKeys := make([][]byte, 0)
 	assignedMainChainIDs := make([][]byte, 0)

--- a/cmd/sovereignnode/chainSimulator/tests/epochChange/outGoingOps_test.go
+++ b/cmd/sovereignnode/chainSimulator/tests/epochChange/outGoingOps_test.go
@@ -41,13 +41,9 @@ func getBridgeDataFromPrevBlock(
 
 	bridgeData := nodeHandler.GetRunTypeComponents().OutGoingOperationsPoolHandler().Get(outGoingMBHdr[0].GetOutGoingOperationsHash())
 	require.True(t, len(bridgeData.OutGoingOperations) >= 1)
-	for _, outGoingOp := range bridgeData.OutGoingOperations {
-		if outGoingOp.Type == int32(mbType) {
-			require.NotEmpty(t, bridgeData.AggregatedSignature)
-			require.NotEmpty(t, bridgeData.LeaderSignature)
-			require.NotEmpty(t, bridgeData.PubKeysBitmap)
-		}
-	}
+	require.NotEmpty(t, bridgeData.AggregatedSignature)
+	require.NotEmpty(t, bridgeData.LeaderSignature)
+	require.NotEmpty(t, bridgeData.PubKeysBitmap)
 
 	return prevHdr.GetNonce(), bridgeData
 }

--- a/cmd/sovereignnode/chainSimulator/tests/processBlock/incomingHeader_test.go
+++ b/cmd/sovereignnode/chainSimulator/tests/processBlock/incomingHeader_test.go
@@ -481,7 +481,8 @@ func TestSovereignChainSimulator_ConfirmBridgeOpChangeValidatorSet(t *testing.T)
 
 		unconfirmedOps := nodeHandler.GetRunTypeComponents().OutGoingOperationsPoolHandler().GetUnconfirmedOperations()
 		require.Len(t, unconfirmedOps, 1)
-		require.Equal(t, int32(block.OutGoingMbChangeValidatorSet), unconfirmedOps[0].Type)
+		require.Len(t, unconfirmedOps[0].OutGoingOperations, 1)
+		require.Equal(t, int32(block.OutGoingMbChangeValidatorSet), unconfirmedOps[0].OutGoingOperations[0].Type)
 		require.Equal(t, uint32(epoch), unconfirmedOps[0].Epoch)
 
 		hashOfHashes := unconfirmedOps[0].Hash

--- a/consensus/spos/bls/sovereign/sovereignSubRoundEnd.go
+++ b/consensus/spos/bls/sovereign/sovereignSubRoundEnd.go
@@ -109,7 +109,8 @@ func (sr *sovereignSubRoundEnd) updatePoolForOutGoingMiniBlock(
 	outGoingMBHeader data.OutGoingMiniBlockHeaderHandler,
 	cnsDta *consensus.Message,
 ) error {
-	mbType := block.OutGoingMBType(outGoingMBHeader.GetOutGoingMBTypeInt32()).String()
+	// TODO: Marius C. : MX-17260 Here AND everywhere else we should refactor extra sigs to be per chain
+	mbType := block.OutGoingMBType(outGoingMBHeader.GetChainID()).String()
 	extraSigData, found := cnsDta.ExtraSignatures[mbType]
 	if !found {
 		return fmt.Errorf("%w for type %s", bls.ErrExtraSigShareDataNotFound, mbType)
@@ -263,7 +264,7 @@ func (sr *sovereignSubRoundEnd) getCurrentOperationsWithSignaturesAfterAndromeda
 
 	currentOperations := make([]*sovereign.BridgeOutGoingData, len(outGoingMBHeaders))
 	for idx, outGoingMBHdr := range outGoingMBHeaders {
-		mbType := block.OutGoingMBType(outGoingMBHdr.GetOutGoingMBTypeInt32()).String()
+		mbType := block.OutGoingMBType(outGoingMBHdr.GetChainID()).String()
 		extraSigData, found := proof.GetExtraSignatureHandlers()[mbType]
 		if !found {
 			return nil, fmt.Errorf("%w for type %s in sovereignSubRoundEnd.getCurrentOperationsWithSignatures", bls.ErrExtraSigShareDataNotFound, mbType)

--- a/consensus/spos/bls/sovereign/sovereignSubRoundEnd_test.go
+++ b/consensus/spos/bls/sovereign/sovereignSubRoundEnd_test.go
@@ -381,10 +381,10 @@ func TestSovereignSubRoundEnd_DoEndJobByLeader(t *testing.T) {
 				switch getCallCt {
 				case 0:
 					return &sovCore.BridgeOutGoingData{
-						Type: int32(block.OutGoingMbDeposit),
 						Hash: outGoingDataHash,
 						OutGoingOperations: []*sovCore.OutGoingOperation{
 							{
+								Type: int32(block.OutGoingMbDeposit),
 								Hash: outGoingOpHash,
 								Data: outGoingOpData,
 							},
@@ -401,10 +401,10 @@ func TestSovereignSubRoundEnd_DoEndJobByLeader(t *testing.T) {
 			},
 			AddCalled: func(data *sovCore.BridgeOutGoingData) {
 				require.Equal(t, &sovCore.BridgeOutGoingData{
-					Type: int32(block.OutGoingMbDeposit),
 					Hash: outGoingDataHash,
 					OutGoingOperations: []*sovCore.OutGoingOperation{
 						{
+							Type: int32(block.OutGoingMbDeposit),
 							Hash: outGoingOpHash,
 							Data: outGoingOpData,
 						},
@@ -436,10 +436,10 @@ func TestSovereignSubRoundEnd_DoEndJobByLeader(t *testing.T) {
 				require.Equal(t, &sovCore.BridgeOperations{
 					Data: []*sovCore.BridgeOutGoingData{
 						{
-							Type: int32(block.OutGoingMbDeposit),
 							Hash: outGoingDataHash,
 							OutGoingOperations: []*sovCore.OutGoingOperation{
 								{
+									Type: int32(block.OutGoingMbDeposit),
 									Hash: outGoingOpHash,
 									Data: outGoingOpData,
 								},
@@ -527,10 +527,10 @@ func TestSovereignSubRoundEnd_DoEndJobByLeader(t *testing.T) {
 		wg := sync.WaitGroup{}
 		wg.Add(1)
 		currentBridgeOutGoingData1 := &sovCore.BridgeOutGoingData{
-			Type: int32(block.OutGoingMbDeposit),
 			Hash: outGoingDataHash1,
 			OutGoingOperations: []*sovCore.OutGoingOperation{
 				{
+					Type: int32(block.OutGoingMbDeposit),
 					Hash: outGoingOpHash1,
 					Data: outGoingOpData1,
 				},
@@ -542,10 +542,10 @@ func TestSovereignSubRoundEnd_DoEndJobByLeader(t *testing.T) {
 		}
 
 		currentBridgeOutGoingData2 := &sovCore.BridgeOutGoingData{
-			Type: int32(block.OutGoingMbChangeValidatorSet),
 			Hash: outGoingDataHash2,
 			OutGoingOperations: []*sovCore.OutGoingOperation{
 				{
+					Type: int32(block.OutGoingMbChangeValidatorSet),
 					Hash: outGoingOpHash2,
 					Data: outGoingOpData2,
 				},
@@ -561,10 +561,10 @@ func TestSovereignSubRoundEnd_DoEndJobByLeader(t *testing.T) {
 				switch string(hash) {
 				case string(outGoingDataHash1):
 					return &sovCore.BridgeOutGoingData{
-						Type: int32(block.OutGoingMbDeposit),
 						Hash: outGoingDataHash1,
 						OutGoingOperations: []*sovCore.OutGoingOperation{
 							{
+								Type: int32(block.OutGoingMbDeposit),
 								Hash: outGoingOpHash1,
 								Data: outGoingOpData1,
 							},
@@ -575,10 +575,10 @@ func TestSovereignSubRoundEnd_DoEndJobByLeader(t *testing.T) {
 					}
 				case string(outGoingDataHash2):
 					return &sovCore.BridgeOutGoingData{
-						Type: int32(block.OutGoingMbChangeValidatorSet),
 						Hash: outGoingDataHash2,
 						OutGoingOperations: []*sovCore.OutGoingOperation{
 							{
+								Type: int32(block.OutGoingMbChangeValidatorSet),
 								Hash: outGoingOpHash2,
 								Data: outGoingOpData2,
 							},
@@ -622,13 +622,11 @@ func TestSovereignSubRoundEnd_DoEndJobByLeader(t *testing.T) {
 			},
 			OutGoingMiniBlockHeaders: []*block.OutGoingMiniBlockHeader{
 				{
-					Type:                                  block.OutGoingMbDeposit,
 					OutGoingOperationsHash:                outGoingDataHash1,
 					AggregatedSignatureOutGoingOperations: aggregatedSig1,
 					LeaderSignatureOutGoingOperations:     leaderSig1,
 				},
 				{
-					Type:                                  block.OutGoingMbChangeValidatorSet,
 					OutGoingOperationsHash:                outGoingDataHash2,
 					AggregatedSignatureOutGoingOperations: aggregatedSig2,
 					LeaderSignatureOutGoingOperations:     leaderSig2,

--- a/factory/runType/sovereignRunTypeComponents.go
+++ b/factory/runType/sovereignRunTypeComponents.go
@@ -289,6 +289,7 @@ func (rcf *sovereignRunTypeComponentsFactory) createOutGoingTxDataSigners() (bls
 	signRoundExtraSignersHolder := holders.NewSubRoundSignatureExtraSignersHolder()
 	endRoundExtraSignersHolder := holders.NewSubRoundEndExtraSignersHolder()
 
+	// Maybe here we should prepare code to iterate through chains?
 	for _, mbTypeValue := range dataBlock.OutGoingMBType_value {
 		mbType := dataBlock.OutGoingMBType(mbTypeValue)
 		extraSignerHandler := rcf.cryptoComponents.ConsensusSigningHandler().ShallowClone()

--- a/factory/runType/sovereignRunTypeComponents.go
+++ b/factory/runType/sovereignRunTypeComponents.go
@@ -289,38 +289,38 @@ func (rcf *sovereignRunTypeComponentsFactory) createOutGoingTxDataSigners() (bls
 	signRoundExtraSignersHolder := holders.NewSubRoundSignatureExtraSignersHolder()
 	endRoundExtraSignersHolder := holders.NewSubRoundEndExtraSignersHolder()
 
-	// Maybe here we should prepare code to iterate through chains?
-	for _, mbTypeValue := range dataBlock.OutGoingMBType_value {
-		mbType := dataBlock.OutGoingMBType(mbTypeValue)
-		extraSignerHandler := rcf.cryptoComponents.ConsensusSigningHandler().ShallowClone()
+	// TODO: Marius C: Maybe here we should prepare code to iterate through chains?
+	//for _, mbTypeValue := range dataBlock.OutGoingMBType_value {
+	mbType := dataBlock.OutGoingMBType(0)
+	extraSignerHandler := rcf.cryptoComponents.ConsensusSigningHandler().ShallowClone()
 
-		startRoundExtraSignerOutGoingTx, err := extraSigners.NewSovereignSubRoundStartExtraSigner(extraSignerHandler, mbType)
-		if err != nil {
-			return nil, err
-		}
-		err = startRoundExtraSignersHolder.RegisterExtraSigningHandler(startRoundExtraSignerOutGoingTx)
-		if err != nil {
-			return nil, err
-		}
-
-		signRoundExtraSignerOutGoingTx, err := extraSigners.NewSovereignSubRoundSignatureExtraSigner(extraSignerHandler, mbType)
-		if err != nil {
-			return nil, err
-		}
-		err = signRoundExtraSignersHolder.RegisterExtraSigningHandler(signRoundExtraSignerOutGoingTx)
-		if err != nil {
-			return nil, err
-		}
-
-		endRoundExtraSignerOutGoingTx, err := extraSigners.NewSovereignSubRoundEndExtraSigner(extraSignerHandler, mbType, rcf.coreComponents.EnableEpochsHandler())
-		if err != nil {
-			return nil, err
-		}
-		err = endRoundExtraSignersHolder.RegisterExtraSigningHandler(endRoundExtraSignerOutGoingTx)
-		if err != nil {
-			return nil, err
-		}
+	startRoundExtraSignerOutGoingTx, err := extraSigners.NewSovereignSubRoundStartExtraSigner(extraSignerHandler, mbType)
+	if err != nil {
+		return nil, err
 	}
+	err = startRoundExtraSignersHolder.RegisterExtraSigningHandler(startRoundExtraSignerOutGoingTx)
+	if err != nil {
+		return nil, err
+	}
+
+	signRoundExtraSignerOutGoingTx, err := extraSigners.NewSovereignSubRoundSignatureExtraSigner(extraSignerHandler, mbType)
+	if err != nil {
+		return nil, err
+	}
+	err = signRoundExtraSignersHolder.RegisterExtraSigningHandler(signRoundExtraSignerOutGoingTx)
+	if err != nil {
+		return nil, err
+	}
+
+	endRoundExtraSignerOutGoingTx, err := extraSigners.NewSovereignSubRoundEndExtraSigner(extraSignerHandler, mbType, rcf.coreComponents.EnableEpochsHandler())
+	if err != nil {
+		return nil, err
+	}
+	err = endRoundExtraSignersHolder.RegisterExtraSigningHandler(endRoundExtraSignerOutGoingTx)
+	if err != nil {
+		return nil, err
+	}
+	//}
 
 	return holders.NewExtraSignersHolder(
 		startRoundExtraSignersHolder,

--- a/factory/runType/sovereignRunTypeComponents.go
+++ b/factory/runType/sovereignRunTypeComponents.go
@@ -289,7 +289,7 @@ func (rcf *sovereignRunTypeComponentsFactory) createOutGoingTxDataSigners() (bls
 	signRoundExtraSignersHolder := holders.NewSubRoundSignatureExtraSignersHolder()
 	endRoundExtraSignersHolder := holders.NewSubRoundEndExtraSignersHolder()
 
-	// TODO: Marius C: Maybe here we should prepare code to iterate through chains?
+	// TODO: Marius C: MX-17260 Here we should prepare code to iterate through chains
 	//for _, mbTypeValue := range dataBlock.OutGoingMBType_value {
 	mbType := dataBlock.OutGoingMBType(0)
 	extraSignerHandler := rcf.cryptoComponents.ConsensusSigningHandler().ShallowClone()

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/multiversx/mx-chain-go
 
 replace (
-	github.com/multiversx/mx-chain-core-go => github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20251020115405-48b50ee33ea0
+	github.com/multiversx/mx-chain-core-go => github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20251021123023-071209136bd3
 	github.com/multiversx/mx-chain-es-indexer-go => github.com/multiversx/mx-chain-es-indexer-sovereign-go v1.7.17-0.20250826102827-1b5ebecb30da
 	github.com/multiversx/mx-chain-vm-common-go => github.com/multiversx/mx-chain-vm-common-sovereign-go v1.5.17-0.20250715144941-88820f3a7c28
 )

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/multiversx/mx-chain-go
 
 replace (
-	github.com/multiversx/mx-chain-core-go => github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20251021123023-071209136bd3
+	github.com/multiversx/mx-chain-core-go => github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20251022095915-f9ac02331b58
 	github.com/multiversx/mx-chain-es-indexer-go => github.com/multiversx/mx-chain-es-indexer-sovereign-go v1.7.17-0.20250826102827-1b5ebecb30da
 	github.com/multiversx/mx-chain-vm-common-go => github.com/multiversx/mx-chain-vm-common-sovereign-go v1.5.17-0.20250715144941-88820f3a7c28
 )

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/multiversx/mx-chain-go
 
 replace (
-	github.com/multiversx/mx-chain-core-go => github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20250909112243-f8ad1a2c5594
+	github.com/multiversx/mx-chain-core-go => github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20251017125532-29f249ee0fc6
 	github.com/multiversx/mx-chain-es-indexer-go => github.com/multiversx/mx-chain-es-indexer-sovereign-go v1.7.17-0.20250826102827-1b5ebecb30da
 	github.com/multiversx/mx-chain-vm-common-go => github.com/multiversx/mx-chain-vm-common-sovereign-go v1.5.17-0.20250715144941-88820f3a7c28
 )

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/multiversx/mx-chain-go
 
 replace (
-	github.com/multiversx/mx-chain-core-go => github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20251017125532-29f249ee0fc6
+	github.com/multiversx/mx-chain-core-go => github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20251020115405-48b50ee33ea0
 	github.com/multiversx/mx-chain-es-indexer-go => github.com/multiversx/mx-chain-es-indexer-sovereign-go v1.7.17-0.20250826102827-1b5ebecb30da
 	github.com/multiversx/mx-chain-vm-common-go => github.com/multiversx/mx-chain-vm-common-sovereign-go v1.5.17-0.20250715144941-88820f3a7c28
 )

--- a/go.sum
+++ b/go.sum
@@ -405,8 +405,8 @@ github.com/multiversx/concurrent-map v0.1.4 h1:hdnbM8VE4b0KYJaGY5yJS2aNIW9TFFsUY
 github.com/multiversx/concurrent-map v0.1.4/go.mod h1:8cWFRJDOrWHOTNSqgYCUvwT7c7eFQ4U2vKMOp4A/9+o=
 github.com/multiversx/mx-chain-communication-go v1.3.0 h1:ziNM1dRuiR/7al2L/jGEA/a/hjurtJ/HEqgazHNt9P8=
 github.com/multiversx/mx-chain-communication-go v1.3.0/go.mod h1:gDVWn6zUW6aCN1YOm/FbbT5MUmhgn/L1Rmpl8EoH3Yg=
-github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20250909112243-f8ad1a2c5594 h1:E3gBrupBJb3S1angsgq1h+ZoM2Svnn8xkEmQC+WEF/0=
-github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20250909112243-f8ad1a2c5594/go.mod h1:cJw3+5HfcHb5uIf3f/0cjYBXq6jumM3TNeQAY8UQFF0=
+github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20251020115405-48b50ee33ea0 h1:+jAcIMse+LBnjh0FAdIfcnKYPeCLoFHxsDW9BXxg7+M=
+github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20251020115405-48b50ee33ea0/go.mod h1:8VKRU04HXXGELmzoIh9x2oYtWEatOZtgd8Mou6rAT8I=
 github.com/multiversx/mx-chain-crypto-go v1.3.0 h1:0eK2bkDOMi8VbSPrB1/vGJSYT81IBtfL4zw+C4sWe/k=
 github.com/multiversx/mx-chain-crypto-go v1.3.0/go.mod h1:nPIkxxzyTP8IquWKds+22Q2OJ9W7LtusC7cAosz7ojM=
 github.com/multiversx/mx-chain-es-indexer-sovereign-go v1.7.17-0.20250826102827-1b5ebecb30da h1:7CAv12kiimjdv+odZGJ262EREeyi1/e+fBwJqPWGst0=

--- a/go.sum
+++ b/go.sum
@@ -405,8 +405,8 @@ github.com/multiversx/concurrent-map v0.1.4 h1:hdnbM8VE4b0KYJaGY5yJS2aNIW9TFFsUY
 github.com/multiversx/concurrent-map v0.1.4/go.mod h1:8cWFRJDOrWHOTNSqgYCUvwT7c7eFQ4U2vKMOp4A/9+o=
 github.com/multiversx/mx-chain-communication-go v1.3.0 h1:ziNM1dRuiR/7al2L/jGEA/a/hjurtJ/HEqgazHNt9P8=
 github.com/multiversx/mx-chain-communication-go v1.3.0/go.mod h1:gDVWn6zUW6aCN1YOm/FbbT5MUmhgn/L1Rmpl8EoH3Yg=
-github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20251021123023-071209136bd3 h1:vib5GH68e0JEKEHMSyKJy+VoWtOuAmtQyzpV6maUNlI=
-github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20251021123023-071209136bd3/go.mod h1:8VKRU04HXXGELmzoIh9x2oYtWEatOZtgd8Mou6rAT8I=
+github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20251022095915-f9ac02331b58 h1:eSaK55GVwmU4/MPtR/iwhuABDzyrzU9deouec9vy9cc=
+github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20251022095915-f9ac02331b58/go.mod h1:8VKRU04HXXGELmzoIh9x2oYtWEatOZtgd8Mou6rAT8I=
 github.com/multiversx/mx-chain-crypto-go v1.3.0 h1:0eK2bkDOMi8VbSPrB1/vGJSYT81IBtfL4zw+C4sWe/k=
 github.com/multiversx/mx-chain-crypto-go v1.3.0/go.mod h1:nPIkxxzyTP8IquWKds+22Q2OJ9W7LtusC7cAosz7ojM=
 github.com/multiversx/mx-chain-es-indexer-sovereign-go v1.7.17-0.20250826102827-1b5ebecb30da h1:7CAv12kiimjdv+odZGJ262EREeyi1/e+fBwJqPWGst0=

--- a/go.sum
+++ b/go.sum
@@ -405,8 +405,8 @@ github.com/multiversx/concurrent-map v0.1.4 h1:hdnbM8VE4b0KYJaGY5yJS2aNIW9TFFsUY
 github.com/multiversx/concurrent-map v0.1.4/go.mod h1:8cWFRJDOrWHOTNSqgYCUvwT7c7eFQ4U2vKMOp4A/9+o=
 github.com/multiversx/mx-chain-communication-go v1.3.0 h1:ziNM1dRuiR/7al2L/jGEA/a/hjurtJ/HEqgazHNt9P8=
 github.com/multiversx/mx-chain-communication-go v1.3.0/go.mod h1:gDVWn6zUW6aCN1YOm/FbbT5MUmhgn/L1Rmpl8EoH3Yg=
-github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20251020115405-48b50ee33ea0 h1:+jAcIMse+LBnjh0FAdIfcnKYPeCLoFHxsDW9BXxg7+M=
-github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20251020115405-48b50ee33ea0/go.mod h1:8VKRU04HXXGELmzoIh9x2oYtWEatOZtgd8Mou6rAT8I=
+github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20251021123023-071209136bd3 h1:vib5GH68e0JEKEHMSyKJy+VoWtOuAmtQyzpV6maUNlI=
+github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20251021123023-071209136bd3/go.mod h1:8VKRU04HXXGELmzoIh9x2oYtWEatOZtgd8Mou6rAT8I=
 github.com/multiversx/mx-chain-crypto-go v1.3.0 h1:0eK2bkDOMi8VbSPrB1/vGJSYT81IBtfL4zw+C4sWe/k=
 github.com/multiversx/mx-chain-crypto-go v1.3.0/go.mod h1:nPIkxxzyTP8IquWKds+22Q2OJ9W7LtusC7cAosz7ojM=
 github.com/multiversx/mx-chain-es-indexer-sovereign-go v1.7.17-0.20250826102827-1b5ebecb30da h1:7CAv12kiimjdv+odZGJ262EREeyi1/e+fBwJqPWGst0=

--- a/process/block/displayBlock.go
+++ b/process/block/displayBlock.go
@@ -245,11 +245,12 @@ func (txc *transactionCounter) displayOutGoingTxData(
 		"Hash",
 		logger.DisplayByteSlice(outGoingMb.GetHash())}),
 	)
-	lines = append(lines, display.NewLineData(false, []string{
-		"",
-		"Type",
-		block.OutGoingMBType(outGoingMb.GetOutGoingMBTypeInt32()).String()}),
-	)
+	// TODO: Marius C: Here we should only output the chain id
+	//lines = append(lines, display.NewLineData(false, []string{
+	//	"",
+	//	"Type",
+	//	block.OutGoingMBType(outGoingMb.GetOutGoingMBTypeInt32()).String()}),
+	//)
 	lines = append(lines, display.NewLineData(false, []string{
 		"",
 		"OutGoingTxDataHash",

--- a/process/block/displayBlock.go
+++ b/process/block/displayBlock.go
@@ -245,7 +245,7 @@ func (txc *transactionCounter) displayOutGoingTxData(
 		"Hash",
 		logger.DisplayByteSlice(outGoingMb.GetHash())}),
 	)
-	// TODO: Marius C: Here we should only output the chain id
+	// TODO: Marius C: MX-17260 Here we should output the chain id
 	//lines = append(lines, display.NewLineData(false, []string{
 	//	"",
 	//	"Type",

--- a/process/block/displayBlock_test.go
+++ b/process/block/displayBlock_test.go
@@ -51,10 +51,11 @@ func createDisplayLinesForOutGoingMb(outGoingMb *block.OutGoingMiniBlockHeader) 
 			Values:              []string{"OutGoing mini block header", "Hash", hex.EncodeToString(outGoingMb.GetHash())},
 			HorizontalRuleAfter: false,
 		},
-		{
-			Values:              []string{"", "Type", block.OutGoingMBType(outGoingMb.GetOutGoingMBTypeInt32()).String()},
-			HorizontalRuleAfter: false,
-		},
+		// TODO: Marius C: Here we should only output the chain id
+		//{
+		//	Values:              []string{"", "Type", block.OutGoingMBType(outGoingMb.GetOutGoingMBTypeInt32()).String()},
+		//	HorizontalRuleAfter: false,
+		//},
 		{
 			Values:              []string{"", "OutGoingTxDataHash", hex.EncodeToString(outGoingMb.GetOutGoingOperationsHash())},
 			HorizontalRuleAfter: false,
@@ -136,14 +137,12 @@ func TestDisplayBlock_DisplaySovereignChainHeader(t *testing.T) {
 
 	extendedShardHeaderHashes := [][]byte{[]byte("hash1"), []byte("hash2"), []byte("hash3")}
 	outGoingMbHeader1 := &block.OutGoingMiniBlockHeader{
-		Type:                                  block.OutGoingMbDeposit,
 		Hash:                                  []byte("outGoingTxDataHash1"),
 		OutGoingOperationsHash:                []byte("outGoingOperationsHash1"),
 		AggregatedSignatureOutGoingOperations: []byte("aggregatedSig1"),
 		LeaderSignatureOutGoingOperations:     []byte("leaderSig1"),
 	}
 	outGoingMbHeader2 := &block.OutGoingMiniBlockHeader{
-		Type:                                  block.OutGoingMbChangeValidatorSet,
 		Hash:                                  []byte("outGoingTxDataHash2"),
 		OutGoingOperationsHash:                []byte("outGoingOperationsHash2"),
 		AggregatedSignatureOutGoingOperations: []byte("aggregatedSig2"),

--- a/process/block/displayBlock_test.go
+++ b/process/block/displayBlock_test.go
@@ -51,7 +51,7 @@ func createDisplayLinesForOutGoingMb(outGoingMb *block.OutGoingMiniBlockHeader) 
 			Values:              []string{"OutGoing mini block header", "Hash", hex.EncodeToString(outGoingMb.GetHash())},
 			HorizontalRuleAfter: false,
 		},
-		// TODO: Marius C: Here we should only output the chain id
+		// TODO: Marius C: MX-17260 Here we should only output the chain id
 		//{
 		//	Values:              []string{"", "Type", block.OutGoingMBType(outGoingMb.GetOutGoingMBTypeInt32()).String()},
 		//	HorizontalRuleAfter: false,

--- a/process/block/sovereign/incomingHeader/dto/dto.go
+++ b/process/block/sovereign/incomingHeader/dto/dto.go
@@ -1,6 +1,7 @@
 package dto
 
 import (
+	"github.com/multiversx/mx-chain-core-go/data/block"
 	"github.com/multiversx/mx-chain-core-go/data/smartContractResult"
 )
 
@@ -69,4 +70,10 @@ type EventResult struct {
 type EventsResult struct {
 	Scrs               []*SCRInfo
 	ConfirmedBridgeOps []*ConfirmedBridgeOp
+}
+
+type OutGoingOperation struct {
+	Nonce  uint64
+	MBType block.OutGoingMBType
+	Data   []byte
 }

--- a/process/block/sovereign/incomingHeader/dto/dto.go
+++ b/process/block/sovereign/incomingHeader/dto/dto.go
@@ -72,6 +72,7 @@ type EventsResult struct {
 	ConfirmedBridgeOps []*ConfirmedBridgeOp
 }
 
+// OutGoingOperation defines an outgoing operation
 type OutGoingOperation struct {
 	Nonce  uint64
 	MBType block.OutGoingMBType

--- a/process/block/sovereign/interface.go
+++ b/process/block/sovereign/interface.go
@@ -2,15 +2,15 @@ package sovereign
 
 import (
 	"github.com/multiversx/mx-chain-core-go/data"
-	"github.com/multiversx/mx-chain-core-go/data/block"
 	"github.com/multiversx/mx-chain-core-go/data/sovereign"
 	"github.com/multiversx/mx-chain-go/process/block/sovereign/dto"
+	dtoSov "github.com/multiversx/mx-chain-go/process/block/sovereign/incomingHeader/dto"
 )
 
 // OutgoingOperationsFormatter collects relevant outgoing events for bridge from the logs and creates outgoing data
 // that needs to be signed by validators to bridge tokens
 type OutgoingOperationsFormatter interface {
-	CreateOutgoingTxsData(logs []*data.LogData) (map[block.OutGoingMBType][][]byte, error)
+	CreateOutgoingTxsData(logs []*data.LogData) ([]*dtoSov.OutGoingOperation, error)
 	CreateOutGoingChangeValidatorData(pubKeys []string, epoch uint32) ([]byte, error)
 	IsInterfaceNil() bool
 }

--- a/process/block/sovereign/outgoingOperations.go
+++ b/process/block/sovereign/outgoingOperations.go
@@ -8,13 +8,14 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-core-go/data/block"
 	"github.com/multiversx/mx-chain-core-go/data/sovereign"
-	"github.com/multiversx/mx-chain-core-go/marshal/factory"
-	"github.com/multiversx/mx-chain-go/errors"
 	"github.com/multiversx/mx-chain-go/process"
 	"github.com/multiversx/mx-chain-go/process/block/sovereign/incomingHeader/dto"
 	"github.com/multiversx/mx-chain-go/process/block/sovereign/operationFormatters"
-	"github.com/multiversx/mx-chain-go/state"
 	logger "github.com/multiversx/mx-chain-logger-go"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/multiversx/mx-chain-go/errors"
+	"github.com/multiversx/mx-chain-go/state"
 )
 
 type opFormatterData struct {
@@ -309,9 +310,7 @@ func (op *outgoingOperations) CreateOutGoingChangeValidatorData(pubKeys []string
 		validatorsID[idx] = peerAcc.GetMainChainID()
 	}
 
-	mrsh, _ := factory.NewMarshalizer(factory.GogoProtobuf)
-
-	return mrsh.Marshal(&sovereign.BridgeOutGoingDataValidatorSetChange{
+	return proto.Marshal(&sovereign.BridgeOutGoingDataValidatorSetChange{
 		Epoch:     epoch,
 		PubKeyIDs: validatorsID,
 	})

--- a/process/block/sovereign/outgoingOperations.go
+++ b/process/block/sovereign/outgoingOperations.go
@@ -8,13 +8,13 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-core-go/data/block"
 	"github.com/multiversx/mx-chain-core-go/data/sovereign"
-	"github.com/multiversx/mx-chain-go/process"
-	"github.com/multiversx/mx-chain-go/process/block/sovereign/operationFormatters"
-	logger "github.com/multiversx/mx-chain-logger-go"
-	"google.golang.org/protobuf/proto"
-
+	"github.com/multiversx/mx-chain-core-go/marshal/factory"
 	"github.com/multiversx/mx-chain-go/errors"
+	"github.com/multiversx/mx-chain-go/process"
+	"github.com/multiversx/mx-chain-go/process/block/sovereign/incomingHeader/dto"
+	"github.com/multiversx/mx-chain-go/process/block/sovereign/operationFormatters"
 	"github.com/multiversx/mx-chain-go/state"
+	logger "github.com/multiversx/mx-chain-logger-go"
 )
 
 type opFormatterData struct {
@@ -212,15 +212,15 @@ func addHandlerIfSubscribed(
 
 // CreateOutgoingTxsData collects relevant outgoing events(based on subscribed addresses and topics) for bridge from the
 // logs and creates outgoing data that needs to be signed by validators to bridge tokens
-func (op *outgoingOperations) CreateOutgoingTxsData(logs []*data.LogData) (map[block.OutGoingMBType][][]byte, error) {
-	outgoingEvents := op.createOutgoingEvents(logs)
+func (op *outgoingOperations) CreateOutgoingTxsData(logs []*data.LogData) ([]*dto.OutGoingOperation, error) {
+	outgoingEvents := op.collectOutGoingEvents(logs)
 	if len(outgoingEvents) == 0 {
-		return make(map[block.OutGoingMBType][][]byte), nil
+		return make([]*dto.OutGoingOperation, 0), nil
 	}
 
-	txsData := make(map[block.OutGoingMBType][][]byte)
+	operations := make([]*dto.OutGoingOperation, 0)
 	for i, event := range outgoingEvents {
-		operation, mbType, err := op.getOperationData(event)
+		operation, err := op.getOperationData(event)
 		if err != nil {
 			log.Error("outgoingOperations.CreateOutgoingTxsData error",
 				"tx hash", logs[i].TxHash,
@@ -230,15 +230,15 @@ func (op *outgoingOperations) CreateOutgoingTxsData(logs []*data.LogData) (map[b
 			return nil, err
 		}
 
-		txsData[mbType] = append(txsData[mbType], operation)
+		operations = append(operations, operation)
 	}
 
 	// TODO: Check gas limit here and split tx data in multiple batches if required
 	// Task: MX-14720
-	return txsData, nil
+	return operations, nil
 }
 
-func (op *outgoingOperations) createOutgoingEvents(logs []*data.LogData) []data.EventHandler {
+func (op *outgoingOperations) collectOutGoingEvents(logs []*data.LogData) []data.EventHandler {
 	events := make([]data.EventHandler, 0)
 
 	for _, logData := range logs {
@@ -282,15 +282,18 @@ func (op *outgoingOperations) isSubscribed(event data.EventHandler, txHash strin
 	return false
 }
 
-func (op *outgoingOperations) getOperationData(event data.EventHandler) ([]byte, block.OutGoingMBType, error) {
+func (op *outgoingOperations) getOperationData(event data.EventHandler) (*dto.OutGoingOperation, error) {
 	opFormatter, found := op.opFormatters[string(event.GetIdentifier())]
 	if !found {
 		log.Error("outgoingOperations.getOperationData: event not found", "event", string(event.GetIdentifier()))
-		return nil, block.OutGoingMBType(0), errEventIDNotFound
+		return nil, errEventIDNotFound
 	}
 
 	opData, err := opFormatter.handler.CreateOperationData(event)
-	return opData, opFormatter.mbType, err
+	return &dto.OutGoingOperation{
+		MBType: opFormatter.mbType,
+		Data:   opData,
+	}, err
 }
 
 // CreateOutGoingChangeValidatorData will create the necessary outgoing data for validator set change
@@ -306,7 +309,9 @@ func (op *outgoingOperations) CreateOutGoingChangeValidatorData(pubKeys []string
 		validatorsID[idx] = peerAcc.GetMainChainID()
 	}
 
-	return proto.Marshal(&sovereign.BridgeOutGoingDataValidatorSetChange{
+	mrsh, _ := factory.NewMarshalizer(factory.GogoProtobuf)
+
+	return mrsh.Marshal(&sovereign.BridgeOutGoingDataValidatorSetChange{
 		Epoch:     epoch,
 		PubKeyIDs: validatorsID,
 	})

--- a/process/block/sovereign/outgoingOperations_test.go
+++ b/process/block/sovereign/outgoingOperations_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data/block"
 	"github.com/multiversx/mx-chain-core-go/data/sovereign"
 	transactionData "github.com/multiversx/mx-chain-core-go/data/transaction"
+	"github.com/multiversx/mx-chain-go/process/block/sovereign/incomingHeader/dto"
 	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
@@ -381,8 +382,11 @@ func TestOutgoingOperations_CreateOutgoingTxData(t *testing.T) {
 
 	outgoingTxData, err := opFormatter.CreateOutgoingTxsData(logs)
 	require.Nil(t, err)
-	require.Equal(t, map[block.OutGoingMBType][][]byte{
-		block.OutGoingMbDeposit: {operationBytes},
+	require.Equal(t, []*dto.OutGoingOperation{
+		{
+			MBType: block.OutGoingMbDeposit,
+			Data:   operationBytes,
+		},
 	}, outgoingTxData)
 }
 
@@ -462,8 +466,11 @@ func TestOutgoingOperations_CreateOutgoingTxScCall(t *testing.T) {
 
 	outgoingTxData, err := opFormatter.CreateOutgoingTxsData(logs)
 	require.Nil(t, err)
-	require.Equal(t, map[block.OutGoingMBType][][]byte{
-		block.OutGoingMbDeposit: {operationBytes},
+	require.Equal(t, []*dto.OutGoingOperation{
+		{
+			MBType: block.OutGoingMbDeposit,
+			Data:   operationBytes,
+		},
 	}, outgoingTxData)
 }
 

--- a/process/block/sovereign/outgoingOperations_test.go
+++ b/process/block/sovereign/outgoingOperations_test.go
@@ -10,12 +10,13 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data/block"
 	"github.com/multiversx/mx-chain-core-go/data/sovereign"
 	transactionData "github.com/multiversx/mx-chain-core-go/data/transaction"
-	"github.com/multiversx/mx-chain-core-go/marshal/factory"
+	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
 	"github.com/multiversx/mx-chain-go/errors"
 	sovTests "github.com/multiversx/mx-chain-go/testscommon/sovereign"
 	"github.com/multiversx/mx-chain-go/testscommon/state"
-	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
-	"github.com/stretchr/testify/require"
 )
 
 func createEvents() []SubscribedEvent {
@@ -496,10 +497,8 @@ func TestOutgoingOperations_CreateOutGoingChangeValidatorData(t *testing.T) {
 	res, err := formatter.CreateOutGoingChangeValidatorData(pubKeys, 4)
 	require.Nil(t, err)
 
-	mrsh, _ := factory.NewMarshalizer(factory.GogoProtobuf)
-
 	resBridgeData := sovereign.BridgeOutGoingDataValidatorSetChange{}
-	err = mrsh.Unmarshal(&resBridgeData, res)
+	err = proto.Unmarshal(res, &resBridgeData)
 	require.Nil(t, err)
 	require.Equal(t, uint32(4), resBridgeData.GetEpoch())
 	require.Equal(t, [][]byte{[]byte("id1"), []byte("id2")}, resBridgeData.GetPubKeyIDs())

--- a/process/block/sovereign/outgoingOperations_test.go
+++ b/process/block/sovereign/outgoingOperations_test.go
@@ -10,13 +10,12 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data/block"
 	"github.com/multiversx/mx-chain-core-go/data/sovereign"
 	transactionData "github.com/multiversx/mx-chain-core-go/data/transaction"
-	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
-	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/proto"
-
+	"github.com/multiversx/mx-chain-core-go/marshal/factory"
 	"github.com/multiversx/mx-chain-go/errors"
 	sovTests "github.com/multiversx/mx-chain-go/testscommon/sovereign"
 	"github.com/multiversx/mx-chain-go/testscommon/state"
+	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
+	"github.com/stretchr/testify/require"
 )
 
 func createEvents() []SubscribedEvent {
@@ -497,8 +496,10 @@ func TestOutgoingOperations_CreateOutGoingChangeValidatorData(t *testing.T) {
 	res, err := formatter.CreateOutGoingChangeValidatorData(pubKeys, 4)
 	require.Nil(t, err)
 
+	mrsh, _ := factory.NewMarshalizer(factory.GogoProtobuf)
+
 	resBridgeData := sovereign.BridgeOutGoingDataValidatorSetChange{}
-	err = proto.Unmarshal(res, &resBridgeData)
+	err = mrsh.Unmarshal(&resBridgeData, res)
 	require.Nil(t, err)
 	require.Equal(t, uint32(4), resBridgeData.GetEpoch())
 	require.Equal(t, [][]byte{[]byte("id1"), []byte("id2")}, resBridgeData.GetPubKeyIDs())

--- a/process/block/sovereignChainBlock.go
+++ b/process/block/sovereignChainBlock.go
@@ -1690,7 +1690,6 @@ func (scbp *sovereignChainBlockProcessor) createOutGoingMiniBlockData(
 
 	outGoingOperationsHash := scbp.operationsHasher.Compute(string(aggregatedOutGoingOperations))
 	scbp.outGoingOperationsPool.Add(&sovCore.BridgeOutGoingData{
-		//Type:               int32(mbType),
 		Hash:               outGoingOperationsHash,
 		OutGoingOperations: outGoingOperationsData,
 		PubKeysBitmap:      headerHandler.GetPubKeysBitmap(),

--- a/process/block/sovereignChainBlock.go
+++ b/process/block/sovereignChainBlock.go
@@ -1273,7 +1273,6 @@ func (scbp *sovereignChainBlockProcessor) computeEpochChangeOutGoingMBHeaderAndH
 	}
 
 	outGoingMbHeader := &block.OutGoingMiniBlockHeader{
-		Type:                   block.OutGoingMbChangeValidatorSet,
 		Hash:                   outGoingMbHash,
 		OutGoingOperationsHash: outGoingOperationsHash,
 	}
@@ -1289,16 +1288,16 @@ func (scbp *sovereignChainBlockProcessor) computeEpochChangeOutGoingMBHeaderAndH
 func (scbp *sovereignChainBlockProcessor) computeReceivedOutGoingMBHeaderHash(
 	header *block.SovereignChainHeader,
 ) ([]byte, error) {
-	receivedOutGoingMB := header.GetOutGoingMiniBlockHeaderHandler(int32(block.OutGoingMbChangeValidatorSet))
-	if check.IfNil(receivedOutGoingMB) {
+	// TODO: MariusC, here, for multi chain we should iterate through all chains
+	receivedOutGoingMB := header.GetOutGoingMiniBlockHeaderHandlers()
+	if len(receivedOutGoingMB) == 0 {
 		return nil, fmt.Errorf("%w for %s in func computeReceivedOutGoingMBHeaderHash",
 			data.ErrNilOutGoingMiniBlockHeaderHandlerProvided, block.OutGoingMbChangeValidatorSet.String())
 	}
 
 	outGoingMBHeader := &block.OutGoingMiniBlockHeader{
-		Type:                   block.OutGoingMbChangeValidatorSet,
-		Hash:                   receivedOutGoingMB.GetHash(),
-		OutGoingOperationsHash: receivedOutGoingMB.GetOutGoingOperationsHash(),
+		Hash:                   receivedOutGoingMB[0].GetHash(),
+		OutGoingOperationsHash: receivedOutGoingMB[0].GetOutGoingOperationsHash(),
 	}
 
 	return core.CalculateHash(scbp.marshalizer, scbp.hasher, outGoingMBHeader)

--- a/process/block/sovereignChainBlock.go
+++ b/process/block/sovereignChainBlock.go
@@ -1288,7 +1288,7 @@ func (scbp *sovereignChainBlockProcessor) computeEpochChangeOutGoingMBHeaderAndH
 func (scbp *sovereignChainBlockProcessor) computeReceivedOutGoingMBHeaderHash(
 	header *block.SovereignChainHeader,
 ) ([]byte, error) {
-	// TODO: MariusC, here, for multi chain we should iterate through all chains
+	// TODO: MariusC MX-17260 for multi chain we should iterate through all chains
 	receivedOutGoingMB := header.GetOutGoingMiniBlockHeaderHandlers()
 	if len(receivedOutGoingMB) == 0 {
 		return nil, fmt.Errorf("%w for %s in func computeReceivedOutGoingMBHeaderHash",
@@ -1738,7 +1738,6 @@ func (scbp *sovereignChainBlockProcessor) setOutGoingMiniBlock(
 	}
 
 	outGoingMbHeader := &block.OutGoingMiniBlockHeader{
-		//Type:                   mbType,
 		Hash:                   outGoingMbHash,
 		OutGoingOperationsHash: outGoingOperationsHash,
 	}

--- a/process/block/sovereignChainBlock.go
+++ b/process/block/sovereignChainBlock.go
@@ -14,6 +14,7 @@ import (
 	sovCore "github.com/multiversx/mx-chain-core-go/data/sovereign"
 	"github.com/multiversx/mx-chain-core-go/data/transaction"
 	"github.com/multiversx/mx-chain-core-go/hashing"
+	"github.com/multiversx/mx-chain-go/process/block/sovereign/incomingHeader/dto"
 	logger "github.com/multiversx/mx-chain-logger-go"
 
 	"github.com/multiversx/mx-chain-go/common"
@@ -381,9 +382,13 @@ func (scbp *sovereignChainBlockProcessor) createAndSetEpochStartOutGoingOperatio
 	// The rest of the mini-blocks, will be created and processed by all participants on ProcessBlock
 	return scbp.createAndSetOutGoingMiniBlock(
 		header,
-		[][]byte{outGoingOperationChangeValidatorSet},
+		[]*dto.OutGoingOperation{
+			{
+				MBType: block.OutGoingMbChangeValidatorSet,
+				Data:   outGoingOperationChangeValidatorSet,
+			},
+		},
 		body,
-		block.OutGoingMbChangeValidatorSet,
 	)
 }
 
@@ -1254,8 +1259,12 @@ func (scbp *sovereignChainBlockProcessor) computeEpochChangeOutGoingMBHeaderAndH
 
 	outGoingMbChangeValidatorSet, outGoingOperationsHash := scbp.createOutGoingMiniBlockData(
 		header,
-		[][]byte{outGoingOperationChangeValidatorSet},
-		block.OutGoingMbChangeValidatorSet,
+		[]*dto.OutGoingOperation{
+			{
+				MBType: block.OutGoingMbChangeValidatorSet,
+				Data:   outGoingOperationChangeValidatorSet,
+			},
+		},
 	)
 
 	outGoingMbHash, err := core.CalculateHash(scbp.marshalizer, scbp.hasher, outGoingMbChangeValidatorSet)
@@ -1631,16 +1640,13 @@ func (scbp *sovereignChainBlockProcessor) createAndSetOutGoingMiniBlockTxs(heade
 		return err
 	}
 
-	for mbType, outGoingOps := range outGoingOperations {
-		err = scbp.createAndSetOutGoingMiniBlock(
-			headerHandler,
-			outGoingOps,
-			blockBody,
-			mbType,
-		)
-		if err != nil {
-			return err
-		}
+	err = scbp.createAndSetOutGoingMiniBlock(
+		headerHandler,
+		outGoingOperations,
+		blockBody,
+	)
+	if err != nil {
+		return err
 	}
 
 	return nil
@@ -1648,34 +1654,33 @@ func (scbp *sovereignChainBlockProcessor) createAndSetOutGoingMiniBlockTxs(heade
 
 func (scbp *sovereignChainBlockProcessor) createAndSetOutGoingMiniBlock(
 	headerHandler data.HeaderHandler,
-	outGoingOperations [][]byte,
+	outGoingOperations []*dto.OutGoingOperation,
 	blockBody *block.Body,
-	mbType block.OutGoingMBType,
 ) error {
 	if len(outGoingOperations) == 0 {
 		return nil
 	}
 
-	outGoingMb, outGoingOperationsHash := scbp.createOutGoingMiniBlockData(headerHandler, outGoingOperations, mbType)
-	return scbp.setOutGoingMiniBlock(headerHandler, blockBody, outGoingMb, outGoingOperationsHash, mbType)
+	outGoingMb, outGoingOperationsHash := scbp.createOutGoingMiniBlockData(headerHandler, outGoingOperations)
+	return scbp.setOutGoingMiniBlock(headerHandler, blockBody, outGoingMb, outGoingOperationsHash)
 }
 
 func (scbp *sovereignChainBlockProcessor) createOutGoingMiniBlockData(
 	headerHandler data.HeaderHandler,
-	outGoingOperations [][]byte,
-	mbType block.OutGoingMBType,
+	outGoingOperations []*dto.OutGoingOperation,
 ) (*block.MiniBlock, []byte) {
 	outGoingOpHashes := make([][]byte, len(outGoingOperations))
 	aggregatedOutGoingOperations := make([]byte, 0)
 	outGoingOperationsData := make([]*sovCore.OutGoingOperation, 0)
 
 	for idx, outGoingOp := range outGoingOperations {
-		outGoingOpHash := scbp.operationsHasher.Compute(string(outGoingOp))
+		outGoingOpHash := scbp.operationsHasher.Compute(string(outGoingOp.Data))
 		aggregatedOutGoingOperations = append(aggregatedOutGoingOperations, outGoingOpHash...)
 
 		outGoingOpData := &sovCore.OutGoingOperation{
+			Type: int32(outGoingOp.MBType),
 			Hash: outGoingOpHash,
-			Data: outGoingOp,
+			Data: outGoingOp.Data,
 		}
 		outGoingOpHashes[idx] = outGoingOpHash
 		outGoingOperationsData = append(outGoingOperationsData, outGoingOpData)
@@ -1685,7 +1690,7 @@ func (scbp *sovereignChainBlockProcessor) createOutGoingMiniBlockData(
 
 	outGoingOperationsHash := scbp.operationsHasher.Compute(string(aggregatedOutGoingOperations))
 	scbp.outGoingOperationsPool.Add(&sovCore.BridgeOutGoingData{
-		Type:               int32(mbType),
+		//Type:               int32(mbType),
 		Hash:               outGoingOperationsHash,
 		OutGoingOperations: outGoingOperationsData,
 		PubKeysBitmap:      headerHandler.GetPubKeysBitmap(),
@@ -1723,7 +1728,6 @@ func (scbp *sovereignChainBlockProcessor) setOutGoingMiniBlock(
 	createdBlockBody *block.Body,
 	outGoingMb *block.MiniBlock,
 	outGoingOperationsHash []byte,
-	mbType block.OutGoingMBType,
 ) error {
 	outGoingMbHash, err := core.CalculateHash(scbp.marshalizer, scbp.hasher, outGoingMb)
 	if err != nil {
@@ -1736,7 +1740,7 @@ func (scbp *sovereignChainBlockProcessor) setOutGoingMiniBlock(
 	}
 
 	outGoingMbHeader := &block.OutGoingMiniBlockHeader{
-		Type:                   mbType,
+		//Type:                   mbType,
 		Hash:                   outGoingMbHash,
 		OutGoingOperationsHash: outGoingOperationsHash,
 	}

--- a/process/block/sovereignChainBlock_test.go
+++ b/process/block/sovereignChainBlock_test.go
@@ -1334,7 +1334,6 @@ func TestSovereignShardProcessor_ProcessBlock(t *testing.T) {
 		)
 		sovHeader.OutGoingMiniBlockHeaders = []*block.OutGoingMiniBlockHeader{
 			{
-				Type:                   block.OutGoingMbChangeValidatorSet,
 				Hash:                   outGoingMBHash,
 				OutGoingOperationsHash: outGoingOpsHash,
 			},

--- a/process/block/sovereignChainBlock_test.go
+++ b/process/block/sovereignChainBlock_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-core-go/data/block"
 	sovereignCore "github.com/multiversx/mx-chain-core-go/data/sovereign"
+	dtaPool "github.com/multiversx/mx-chain-go/dataRetriever/dataPool/sovereign"
+	"github.com/multiversx/mx-chain-go/process/block/sovereign/incomingHeader/dto"
 	"github.com/stretchr/testify/require"
 
 	"github.com/multiversx/mx-chain-go/common/graceperiod"
@@ -311,11 +313,18 @@ func TestSovereignChainBlockProcessor_createAndSetOutGoingMiniBlockTxs(t *testin
 	bridgeOpsHash := outgoingOpsHasher.Compute(string(append(bridgeOp1Hash, bridgeOp2Hash...)))
 
 	outgoingOperationsFormatter := &sovereign.OutgoingOperationsFormatterMock{
-		CreateOutgoingTxDataCalled: func(logs []*data.LogData) (map[block.OutGoingMBType][][]byte, error) {
+		CreateOutgoingTxDataCalled: func(logs []*data.LogData) ([]*dto.OutGoingOperation, error) {
 			require.Equal(t, expectedLogs, logs)
-			return map[block.OutGoingMBType][][]byte{
-					block.OutGoingMbDeposit: {bridgeOp1, bridgeOp2}},
-				nil
+			return []*dto.OutGoingOperation{
+				{
+					MBType: block.OutGoingMbDeposit,
+					Data:   bridgeOp1,
+				},
+				{
+					MBType: block.OutGoingMbDeposit,
+					Data:   bridgeOp2,
+				},
+			}, nil
 		},
 	}
 
@@ -857,6 +866,8 @@ func TestSovereignShardProcessor_CreateBlock(t *testing.T) {
 		}
 
 		sovArgs := createArgsSovereignChainBlockProcessor(arguments)
+		sovArgs.OutGoingOperationsPool = dtaPool.NewOutGoingOperationPool(time.Second)
+
 		outGoingOp := []byte("outGoingOp")
 		sovArgs.OutgoingOperationsFormatter = &sovereign.OutgoingOperationsFormatterMock{
 			CreateOutGoingChangeValidatorDataCalled: func(pubKeys []string, epoch uint32) ([]byte, error) {
@@ -915,7 +926,6 @@ func TestSovereignShardProcessor_CreateBlock(t *testing.T) {
 			IsStartOfEpoch: true,
 			OutGoingMiniBlockHeaders: []*block.OutGoingMiniBlockHeader{
 				{
-					Type:                   block.OutGoingMbChangeValidatorSet,
 					Hash:                   outGoingMBHash,
 					OutGoingOperationsHash: outGoingOpsHash,
 				},
@@ -930,6 +940,14 @@ func TestSovereignShardProcessor_CreateBlock(t *testing.T) {
 		require.Equal(t, expectedSovHeader, hdr)
 		require.Nil(t, err)
 		require.Equal(t, expectedBusyIdleSequencePerCall, busyIdleCalled)
+
+		bridgeOp := sovArgs.OutGoingOperationsPool.Get(outGoingOpsHash)
+		require.NotNil(t, bridgeOp)
+		require.Equal(t, bridgeOp.OutGoingOperations, []*sovereignCore.OutGoingOperation{{
+			Type: int32(block.OutGoingMbChangeValidatorSet),
+			Hash: outGoingOpHash,
+			Data: outGoingOp,
+		}})
 	})
 	t.Run("should work with sovereign header", func(t *testing.T) {
 		currentEpoch := uint32(1)

--- a/process/headerCheck/sovereignExtraHeaderSignatureVerifier.go
+++ b/process/headerCheck/sovereignExtraHeaderSignatureVerifier.go
@@ -80,7 +80,7 @@ func (hsv *sovereignHeaderSigVerifier) getAggregatedSignature(
 		return nil, process.ErrNilHeaderProof
 	}
 
-	mbTypeStr := block.OutGoingMBType(outGoingMBHdr.GetOutGoingMBTypeInt32()).String()
+	mbTypeStr := block.OutGoingMBType(outGoingMBHdr.GetChainID()).String()
 	extraSigHandler, found := proof.GetExtraSignatureHandlers()[mbTypeStr]
 	if !found {
 		return nil, fmt.Errorf("%w in sovereignHeaderSigVerifier.VerifyAggregatedSignature for header hash: %x, round: %d",

--- a/process/headerCheck/sovereignExtraHeaderSignatureVerifier_test.go
+++ b/process/headerCheck/sovereignExtraHeaderSignatureVerifier_test.go
@@ -99,7 +99,6 @@ func TestSovereignHeaderSigVerifier_getAggregatedSignature(t *testing.T) {
 	outGoingOpHash := []byte("outGoingOpHash")
 	outGoingAggregatedSig := []byte("aggregatedSig")
 	outGoingMBHeader := &block.OutGoingMiniBlockHeader{
-		Type:                                  block.OutGoingMbDeposit,
 		OutGoingOperationsHash:                outGoingOpHash,
 		AggregatedSignatureOutGoingOperations: outGoingAggregatedSig,
 	}
@@ -161,7 +160,6 @@ func TestSovereignHeaderSigVerifier_getLeaderSignedMessage(t *testing.T) {
 	outGoingOpHash := []byte("outGoingOpHash")
 	outGoingAggregatedSig := []byte("aggregatedSig")
 	outGoingMBHeader := &block.OutGoingMiniBlockHeader{
-		Type:                                  block.OutGoingMbDeposit,
 		OutGoingOperationsHash:                outGoingOpHash,
 		AggregatedSignatureOutGoingOperations: outGoingAggregatedSig,
 	}

--- a/testscommon/sovereign/outgoingOperationsFormatterMock.go
+++ b/testscommon/sovereign/outgoingOperationsFormatterMock.go
@@ -2,22 +2,22 @@ package sovereign
 
 import (
 	"github.com/multiversx/mx-chain-core-go/data"
-	"github.com/multiversx/mx-chain-core-go/data/block"
+	"github.com/multiversx/mx-chain-go/process/block/sovereign/incomingHeader/dto"
 )
 
 // OutgoingOperationsFormatterMock -
 type OutgoingOperationsFormatterMock struct {
-	CreateOutgoingTxDataCalled              func(logs []*data.LogData) (map[block.OutGoingMBType][][]byte, error)
+	CreateOutgoingTxDataCalled              func(logs []*data.LogData) ([]*dto.OutGoingOperation, error)
 	CreateOutGoingChangeValidatorDataCalled func(pubKeys []string, epoch uint32) ([]byte, error)
 }
 
 // CreateOutgoingTxsData -
-func (stub *OutgoingOperationsFormatterMock) CreateOutgoingTxsData(logs []*data.LogData) (map[block.OutGoingMBType][][]byte, error) {
+func (stub *OutgoingOperationsFormatterMock) CreateOutgoingTxsData(logs []*data.LogData) ([]*dto.OutGoingOperation, error) {
 	if stub.CreateOutgoingTxDataCalled != nil {
 		return stub.CreateOutgoingTxDataCalled(logs)
 	}
 
-	return make(map[block.OutGoingMBType][][]byte), nil
+	return make([]*dto.OutGoingOperation, 0), nil
 }
 
 // CreateOutGoingChangeValidatorData -


### PR DESCRIPTION
## Reasoning behind the pull request
- Single outgoing mb header with sorted operations per chain
  
## Proposed changes
- `outgoingOperations.CreateOutgoingTxsData` returns **ordered** outoing operations
- Integrate **partially** changes from https://github.com/multiversx/mx-chain-core-sovereign-go/pull/27

## Testing procedure
- 
- 
- 

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
