### PR TITLE
Outgoing op type + chain id

### DIFF
--- a/cmd/sovereignnode/chainSimulator/process/sovereignBlockProcessor.go
+++ b/cmd/sovereignnode/chainSimulator/process/sovereignBlockProcessor.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/multiversx/mx-chain-core-go/data/block"
 	"github.com/multiversx/mx-chain-go/consensus/spos/bls"
 	"github.com/multiversx/mx-chain-go/consensus/spos/bls/sovereign"
 	sovereignBlock "github.com/multiversx/mx-chain-go/dataRetriever/dataPool/sovereign"
@@ -56,10 +55,10 @@ func (sbpf *sovereignBlockProcessor) ProcessHeaderProof(
 	}
 
 	for _, outGoingMb := range sovHdr.GetOutGoingMiniBlockHeaderHandlers() {
-		mbType := block.OutGoingMBType(outGoingMb.GetChainID()).String()
-		extraSigData, found := proof.GetExtraSignatureHandlers()[mbType]
+		chainID := outGoingMb.GetChainID().String()
+		extraSigData, found := proof.GetExtraSignatureHandlers()[chainID]
 		if !found {
-			return fmt.Errorf("%w for type %s in ProcessHeaderProof", bls.ErrExtraSigShareDataNotFound, mbType)
+			return fmt.Errorf("%w for type %s in ProcessHeaderProof", bls.ErrExtraSigShareDataNotFound, chainID)
 		}
 
 		_, err := sovereign.UpdateBridgeDataWithSignatures(&sovereign.BridgeDataSignatures{

--- a/cmd/sovereignnode/chainSimulator/tests/epochChange/epochChange_test.go
+++ b/cmd/sovereignnode/chainSimulator/tests/epochChange/epochChange_test.go
@@ -357,7 +357,7 @@ func checkOutGoingMiniBlockChangeValidatorSet(
 
 	bridgeData := nodeHandler.GetRunTypeComponents().OutGoingOperationsPoolHandler().Get(outGoingMBHdrs[0].GetOutGoingOperationsHash())
 	require.Len(t, bridgeData.OutGoingOperations, 1)
-	require.Equal(t, int32(block.OutGoingMbChangeValidatorSet), bridgeData.OutGoingOperations[0].Type)
+	require.Equal(t, int32(block.OutGoingOpChangeValidatorSet), bridgeData.OutGoingOperations[0].Type)
 	require.Equal(t, currentHeader.GetEpoch(), bridgeData.Epoch)
 
 	outGoingBridgeDataValidators := &sovereignData.BridgeOutGoingDataValidatorSetChange{}

--- a/cmd/sovereignnode/chainSimulator/tests/epochChange/outGoingOps_test.go
+++ b/cmd/sovereignnode/chainSimulator/tests/epochChange/outGoingOps_test.go
@@ -60,7 +60,7 @@ func checkOutGoingMiniBlockRegisterValidator(
 	expectedMainChainIDs := make([][]byte, 0)
 	numOutGoingOpsRegisterBlsKey := 0
 	for _, op := range bridgeData.OutGoingOperations {
-		if op.Type != int32(block.OutGoingMBRegisterBlsKey) {
+		if op.Type != int32(block.OutGoingOpRegisterBlsKey) {
 			continue
 		}
 
@@ -97,7 +97,7 @@ func checkOutGoingMiniBlockUnRegisterValidator(
 	assignedMainChainIDs := make([][]byte, 0)
 	numOutGoingOpsUnregisterBlsKey := 0
 	for _, op := range bridgeData.OutGoingOperations {
-		if op.Type != int32(block.OutGoingMBUnRegisterBlsKey) {
+		if op.Type != int32(block.OutGoingOpUnRegisterBlsKey) {
 			continue
 		}
 

--- a/cmd/sovereignnode/chainSimulator/tests/processBlock/incomingHeader_test.go
+++ b/cmd/sovereignnode/chainSimulator/tests/processBlock/incomingHeader_test.go
@@ -482,7 +482,7 @@ func TestSovereignChainSimulator_ConfirmBridgeOpChangeValidatorSet(t *testing.T)
 		unconfirmedOps := nodeHandler.GetRunTypeComponents().OutGoingOperationsPoolHandler().GetUnconfirmedOperations()
 		require.Len(t, unconfirmedOps, 1)
 		require.Len(t, unconfirmedOps[0].OutGoingOperations, 1)
-		require.Equal(t, int32(block.OutGoingMbChangeValidatorSet), unconfirmedOps[0].OutGoingOperations[0].Type)
+		require.Equal(t, int32(block.OutGoingOpChangeValidatorSet), unconfirmedOps[0].OutGoingOperations[0].Type)
 		require.Equal(t, uint32(epoch), unconfirmedOps[0].Epoch)
 
 		hashOfHashes := unconfirmedOps[0].Hash

--- a/consensus/spos/bls/sovereign/sovereignSubRoundEnd.go
+++ b/consensus/spos/bls/sovereign/sovereignSubRoundEnd.go
@@ -8,7 +8,6 @@ import (
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/core/check"
 	"github.com/multiversx/mx-chain-core-go/data"
-	"github.com/multiversx/mx-chain-core-go/data/block"
 	"github.com/multiversx/mx-chain-core-go/data/sovereign"
 	"github.com/multiversx/mx-chain-go/common"
 	"github.com/multiversx/mx-chain-go/consensus"
@@ -110,10 +109,10 @@ func (sr *sovereignSubRoundEnd) updatePoolForOutGoingMiniBlock(
 	cnsDta *consensus.Message,
 ) error {
 	// TODO: Marius C. : MX-17260 Here AND everywhere else we should refactor extra sigs to be per chain
-	mbType := block.OutGoingMBType(outGoingMBHeader.GetChainID()).String()
-	extraSigData, found := cnsDta.ExtraSignatures[mbType]
+	chainID := outGoingMBHeader.GetChainID().String()
+	extraSigData, found := cnsDta.ExtraSignatures[chainID]
 	if !found {
-		return fmt.Errorf("%w for type %s", bls.ErrExtraSigShareDataNotFound, mbType)
+		return fmt.Errorf("%w for type %s", bls.ErrExtraSigShareDataNotFound, chainID)
 	}
 
 	err := outGoingMBHeader.SetAggregatedSignatureOutGoingOperations(extraSigData.AggregatedSignatureOutGoingTxData)
@@ -131,7 +130,7 @@ func (sr *sovereignSubRoundEnd) updatePoolForOutGoingMiniBlock(
 	log.Debug("step 3.1: block header final info has been received with outgoing mb",
 		"LeaderSignatureOutGoingTxData", extraSigData.LeaderSignatureOutGoingTxData,
 		"AggregatedSignatureOutGoingTxData", extraSigData.AggregatedSignatureOutGoingTxData,
-		"type", mbType,
+		"chain ID", chainID,
 	)
 
 	_, err = UpdateBridgeDataWithSignatures(&BridgeDataSignatures{
@@ -264,10 +263,10 @@ func (sr *sovereignSubRoundEnd) getCurrentOperationsWithSignaturesAfterAndromeda
 
 	currentOperations := make([]*sovereign.BridgeOutGoingData, len(outGoingMBHeaders))
 	for idx, outGoingMBHdr := range outGoingMBHeaders {
-		mbType := block.OutGoingMBType(outGoingMBHdr.GetChainID()).String()
-		extraSigData, found := proof.GetExtraSignatureHandlers()[mbType]
+		chainID := outGoingMBHdr.GetChainID().String()
+		extraSigData, found := proof.GetExtraSignatureHandlers()[chainID]
 		if !found {
-			return nil, fmt.Errorf("%w for type %s in sovereignSubRoundEnd.getCurrentOperationsWithSignatures", bls.ErrExtraSigShareDataNotFound, mbType)
+			return nil, fmt.Errorf("%w for type %s in sovereignSubRoundEnd.getCurrentOperationsWithSignatures", bls.ErrExtraSigShareDataNotFound, chainID)
 		}
 
 		currBridgeData, err := UpdateBridgeDataWithSignatures(&BridgeDataSignatures{

--- a/consensus/spos/bls/sovereign/sovereignSubRoundEnd.go
+++ b/consensus/spos/bls/sovereign/sovereignSubRoundEnd.go
@@ -108,7 +108,6 @@ func (sr *sovereignSubRoundEnd) updatePoolForOutGoingMiniBlock(
 	outGoingMBHeader data.OutGoingMiniBlockHeaderHandler,
 	cnsDta *consensus.Message,
 ) error {
-	// TODO: Marius C. : MX-17260 Here AND everywhere else we should refactor extra sigs to be per chain
 	chainID := outGoingMBHeader.GetChainID().String()
 	extraSigData, found := cnsDta.ExtraSignatures[chainID]
 	if !found {

--- a/consensus/spos/bls/sovereign/sovereignSubRoundEnd_test.go
+++ b/consensus/spos/bls/sovereign/sovereignSubRoundEnd_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-core-go/data/block"
 	sovCore "github.com/multiversx/mx-chain-core-go/data/sovereign"
+	"github.com/multiversx/mx-chain-core-go/data/sovereign/dto"
 	blsSov "github.com/multiversx/mx-chain-go/consensus/spos/bls/sovereign"
 	v1 "github.com/multiversx/mx-chain-go/consensus/spos/bls/v1"
 	"github.com/multiversx/mx-chain-go/testscommon"
@@ -461,6 +462,7 @@ func TestSovereignSubRoundEnd_DoEndJobByLeader(t *testing.T) {
 			},
 			OutGoingMiniBlockHeaders: []*block.OutGoingMiniBlockHeader{
 				{
+					ChainID: dto.MVX,
 					// No extra data needed in this outgoing mb, since those are found in proof
 					OutGoingOperationsHash: outGoingDataHash,
 				},
@@ -496,7 +498,7 @@ func TestSovereignSubRoundEnd_DoEndJobByLeader(t *testing.T) {
 
 		// Add extra sigs proof data and it should work
 		proof.ExtraSignatures = map[string]*block.ExtraSignatureData{
-			block.OutGoingOpDeposit.String(): {
+			dto.MVX.String(): {
 				AggregatedSignature: aggregatedSig,
 				LeaderSignature:     leaderSig,
 			},
@@ -1103,6 +1105,7 @@ func TestSovereignSubRoundEnd_ReceivedBlockHeaderFinalInfo(t *testing.T) {
 		},
 		OutGoingMiniBlockHeaders: []*block.OutGoingMiniBlockHeader{
 			{
+				ChainID:                dto.MVX,
 				Hash:                   []byte("hashOfHashes"),
 				OutGoingOperationsHash: []byte("hashOfHashes"),
 			},
@@ -1118,7 +1121,7 @@ func TestSovereignSubRoundEnd_ReceivedBlockHeaderFinalInfo(t *testing.T) {
 		PubKey:          []byte("A"),
 		InvalidSigners:  []byte("invalidSignersData"),
 		ExtraSignatures: map[string]*consensus.ExtraSignatureData{
-			block.OutGoingOpDeposit.String(): {
+			dto.MVX.String(): {
 				AggregatedSignatureOutGoingTxData: aggregatedSig,
 				LeaderSignatureOutGoingTxData:     leaderSig,
 			},
@@ -1131,7 +1134,7 @@ func TestSovereignSubRoundEnd_ReceivedBlockHeaderFinalInfo(t *testing.T) {
 	require.False(t, wasDataSent)
 
 	// Header's outgoing mb is updated with signatures from consensus message
-	outGoingMb := sovEndRound.GetHeader().(data.SovereignChainHeaderHandler).GetOutGoingMiniBlockHeaderHandler(int32(block.OutGoingOpDeposit))
+	outGoingMb := sovEndRound.GetHeader().(data.SovereignChainHeaderHandler).GetOutGoingMiniBlockHeaderHandler(dto.MVX)
 	require.Equal(t, leaderSig, outGoingMb.GetLeaderSignatureOutGoingOperations())
 	require.Equal(t, aggregatedSig, outGoingMb.GetAggregatedSignatureOutGoingOperations())
 

--- a/consensus/spos/bls/sovereign/sovereignSubRoundEnd_test.go
+++ b/consensus/spos/bls/sovereign/sovereignSubRoundEnd_test.go
@@ -384,7 +384,7 @@ func TestSovereignSubRoundEnd_DoEndJobByLeader(t *testing.T) {
 						Hash: outGoingDataHash,
 						OutGoingOperations: []*sovCore.OutGoingOperation{
 							{
-								Type: int32(block.OutGoingMbDeposit),
+								Type: int32(block.OutGoingOpDeposit),
 								Hash: outGoingOpHash,
 								Data: outGoingOpData,
 							},
@@ -404,7 +404,7 @@ func TestSovereignSubRoundEnd_DoEndJobByLeader(t *testing.T) {
 					Hash: outGoingDataHash,
 					OutGoingOperations: []*sovCore.OutGoingOperation{
 						{
-							Type: int32(block.OutGoingMbDeposit),
+							Type: int32(block.OutGoingOpDeposit),
 							Hash: outGoingOpHash,
 							Data: outGoingOpData,
 						},
@@ -439,7 +439,7 @@ func TestSovereignSubRoundEnd_DoEndJobByLeader(t *testing.T) {
 							Hash: outGoingDataHash,
 							OutGoingOperations: []*sovCore.OutGoingOperation{
 								{
-									Type: int32(block.OutGoingMbDeposit),
+									Type: int32(block.OutGoingOpDeposit),
 									Hash: outGoingOpHash,
 									Data: outGoingOpData,
 								},
@@ -496,7 +496,7 @@ func TestSovereignSubRoundEnd_DoEndJobByLeader(t *testing.T) {
 
 		// Add extra sigs proof data and it should work
 		proof.ExtraSignatures = map[string]*block.ExtraSignatureData{
-			block.OutGoingMbDeposit.String(): {
+			block.OutGoingOpDeposit.String(): {
 				AggregatedSignature: aggregatedSig,
 				LeaderSignature:     leaderSig,
 			},
@@ -530,7 +530,7 @@ func TestSovereignSubRoundEnd_DoEndJobByLeader(t *testing.T) {
 			Hash: outGoingDataHash1,
 			OutGoingOperations: []*sovCore.OutGoingOperation{
 				{
-					Type: int32(block.OutGoingMbDeposit),
+					Type: int32(block.OutGoingOpDeposit),
 					Hash: outGoingOpHash1,
 					Data: outGoingOpData1,
 				},
@@ -545,7 +545,7 @@ func TestSovereignSubRoundEnd_DoEndJobByLeader(t *testing.T) {
 			Hash: outGoingDataHash2,
 			OutGoingOperations: []*sovCore.OutGoingOperation{
 				{
-					Type: int32(block.OutGoingMbChangeValidatorSet),
+					Type: int32(block.OutGoingOpChangeValidatorSet),
 					Hash: outGoingOpHash2,
 					Data: outGoingOpData2,
 				},
@@ -564,7 +564,7 @@ func TestSovereignSubRoundEnd_DoEndJobByLeader(t *testing.T) {
 						Hash: outGoingDataHash1,
 						OutGoingOperations: []*sovCore.OutGoingOperation{
 							{
-								Type: int32(block.OutGoingMbDeposit),
+								Type: int32(block.OutGoingOpDeposit),
 								Hash: outGoingOpHash1,
 								Data: outGoingOpData1,
 							},
@@ -578,7 +578,7 @@ func TestSovereignSubRoundEnd_DoEndJobByLeader(t *testing.T) {
 						Hash: outGoingDataHash2,
 						OutGoingOperations: []*sovCore.OutGoingOperation{
 							{
-								Type: int32(block.OutGoingMbChangeValidatorSet),
+								Type: int32(block.OutGoingOpChangeValidatorSet),
 								Hash: outGoingOpHash2,
 								Data: outGoingOpData2,
 							},
@@ -1118,7 +1118,7 @@ func TestSovereignSubRoundEnd_ReceivedBlockHeaderFinalInfo(t *testing.T) {
 		PubKey:          []byte("A"),
 		InvalidSigners:  []byte("invalidSignersData"),
 		ExtraSignatures: map[string]*consensus.ExtraSignatureData{
-			block.OutGoingMbDeposit.String(): {
+			block.OutGoingOpDeposit.String(): {
 				AggregatedSignatureOutGoingTxData: aggregatedSig,
 				LeaderSignatureOutGoingTxData:     leaderSig,
 			},
@@ -1131,7 +1131,7 @@ func TestSovereignSubRoundEnd_ReceivedBlockHeaderFinalInfo(t *testing.T) {
 	require.False(t, wasDataSent)
 
 	// Header's outgoing mb is updated with signatures from consensus message
-	outGoingMb := sovEndRound.GetHeader().(data.SovereignChainHeaderHandler).GetOutGoingMiniBlockHeaderHandler(int32(block.OutGoingMbDeposit))
+	outGoingMb := sovEndRound.GetHeader().(data.SovereignChainHeaderHandler).GetOutGoingMiniBlockHeaderHandler(int32(block.OutGoingOpDeposit))
 	require.Equal(t, leaderSig, outGoingMb.GetLeaderSignatureOutGoingOperations())
 	require.Equal(t, aggregatedSig, outGoingMb.GetAggregatedSignatureOutGoingOperations())
 

--- a/consensus/spos/bls/v2/subroundEndRound_test.go
+++ b/consensus/spos/bls/v2/subroundEndRound_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/core/check"
 	"github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-core-go/data/block"
+	"github.com/multiversx/mx-chain-core-go/data/sovereign/dto"
 	crypto "github.com/multiversx/mx-chain-crypto-go"
 	"github.com/multiversx/mx-chain-crypto-go/signing"
 	"github.com/multiversx/mx-chain-crypto-go/signing/mcl"
@@ -713,8 +714,8 @@ func TestSubroundEndRound_CreateAndBroadcastProofShouldBeCalled(t *testing.T) {
 
 	extraAggSig := []byte("extraAggSig")
 	extraAggSigs := map[string][]byte{
-		block.OutGoingMbDeposit.String():            extraAggSig,
-		block.OutGoingMbChangeValidatorSet.String(): nil,
+		dto.MVX.String(): extraAggSig,
+		dto.ETH.String(): nil,
 	}
 
 	chanRcv := make(chan bool, 1)
@@ -724,7 +725,7 @@ func TestSubroundEndRound_CreateAndBroadcastProofShouldBeCalled(t *testing.T) {
 	messenger := &consensusMocks.BroadcastMessengerMock{
 		BroadcastEquivalentProofCalled: func(proof data.HeaderProofHandler, pkBytes []byte) error {
 			require.Equal(t, map[string]data.ExtraSignatureDataHandler{
-				block.OutGoingMbDeposit.String(): &block.ExtraSignatureData{
+				dto.MVX.String(): &block.ExtraSignatureData{
 					AggregatedSignature: extraAggSig,
 					LeaderSignature:     leaderExtraSig,
 				},
@@ -758,7 +759,7 @@ func TestSubroundEndRound_CreateAndBroadcastProofShouldBeCalled(t *testing.T) {
 		GetSubRoundEndExtraSignersHolderCalled: func() bls.SubRoundEndExtraSignersHolder {
 			return &subRounds.SubRoundEndExtraSignersHolderMock{
 				GetLeaderExtraSigCalled: func(header data.HeaderHandler, id string) ([]byte, error) {
-					require.Equal(t, block.OutGoingMbDeposit.String(), id)
+					require.Equal(t, dto.MVX.String(), id)
 					return leaderExtraSig, nil
 				},
 			}

--- a/consensus/spos/extraSigners/sovereignSubRoundEndExtraSigner.go
+++ b/consensus/spos/extraSigners/sovereignSubRoundEndExtraSigner.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/multiversx/mx-chain-core-go/core/check"
 	"github.com/multiversx/mx-chain-core-go/data"
-	"github.com/multiversx/mx-chain-core-go/data/block"
+	"github.com/multiversx/mx-chain-core-go/data/sovereign/dto"
 	logger "github.com/multiversx/mx-chain-logger-go"
 
 	"github.com/multiversx/mx-chain-go/common"
@@ -19,14 +19,14 @@ var log = logger.GetOrCreate("extra-signers")
 
 type sovereignSubRoundEndOutGoingTxData struct {
 	signingHandler      consensus.SigningHandler
-	mbType              block.OutGoingMBType
+	chainID             dto.ChainID
 	enableEpochsHandler common.EnableEpochsHandler
 }
 
 // NewSovereignSubRoundEndExtraSigner creates a new extra signer for sovereign outgoing mini blocks in end subround
 func NewSovereignSubRoundEndExtraSigner(
 	signingHandler consensus.SigningHandler,
-	mbType block.OutGoingMBType,
+	chainID dto.ChainID,
 	enableEpochsHandler common.EnableEpochsHandler,
 ) (*sovereignSubRoundEndOutGoingTxData, error) {
 	if check.IfNil(signingHandler) {
@@ -38,7 +38,7 @@ func NewSovereignSubRoundEndExtraSigner(
 
 	return &sovereignSubRoundEndOutGoingTxData{
 		signingHandler:      signingHandler,
-		mbType:              mbType,
+		chainID:             chainID,
 		enableEpochsHandler: enableEpochsHandler,
 	}, nil
 }
@@ -50,7 +50,7 @@ func (sr *sovereignSubRoundEndOutGoingTxData) VerifyAggregatedSignatures(bitmap 
 		return fmt.Errorf("%w in sovereignSubRoundEndOutGoingTxData.SetAggregatedSignatureInHeader", errors.ErrWrongTypeAssertion)
 	}
 
-	outGoingMb := sovHeader.GetOutGoingMiniBlockHeaderHandler(int32(sr.mbType))
+	outGoingMb := sovHeader.GetOutGoingMiniBlockHeaderHandler(sr.chainID)
 	if check.IfNil(outGoingMb) {
 		return nil
 	}
@@ -65,7 +65,7 @@ func (sr *sovereignSubRoundEndOutGoingTxData) AggregateAndSetSignatures(bitmap [
 		return nil, fmt.Errorf("%w in sovereignSubRoundEndOutGoingTxData.SetAggregatedSignatureInHeader", errors.ErrWrongTypeAssertion)
 	}
 
-	outGoingMb := sovHeader.GetOutGoingMiniBlockHeaderHandler(int32(sr.mbType))
+	outGoingMb := sovHeader.GetOutGoingMiniBlockHeaderHandler(sr.chainID)
 	if check.IfNil(outGoingMb) {
 		return nil, nil
 	}
@@ -90,7 +90,7 @@ func (sr *sovereignSubRoundEndOutGoingTxData) SetAggregatedSignatureInHeader(hea
 		return fmt.Errorf("%w in sovereignSubRoundEndOutGoingTxData.SetAggregatedSignatureInHeader", errors.ErrWrongTypeAssertion)
 	}
 
-	outGoingMb := sovHeader.GetOutGoingMiniBlockHeaderHandler(int32(sr.mbType))
+	outGoingMb := sovHeader.GetOutGoingMiniBlockHeaderHandler(sr.chainID)
 	if check.IfNil(outGoingMb) {
 		return nil
 	}
@@ -110,7 +110,7 @@ func (sr *sovereignSubRoundEndOutGoingTxData) SignAndSetLeaderSignature(header d
 		return fmt.Errorf("%w in sovereignSubRoundEndOutGoingTxData.SetAggregatedSignatureInHeader", errors.ErrWrongTypeAssertion)
 	}
 
-	outGoingMb := sovHeader.GetOutGoingMiniBlockHeaderHandler(int32(sr.mbType))
+	outGoingMb := sovHeader.GetOutGoingMiniBlockHeaderHandler(sr.chainID)
 	if check.IfNil(outGoingMb) {
 		return nil
 	}
@@ -142,14 +142,14 @@ func (sr *sovereignSubRoundEndOutGoingTxData) SetConsensusDataInHeader(header da
 		return fmt.Errorf("%w in sovereignSubRoundEndOutGoingTxData.SetConsensusDataInHeader", errors.ErrWrongTypeAssertion)
 	}
 
-	outGoingMb := sovHeader.GetOutGoingMiniBlockHeaderHandler(int32(sr.mbType))
+	outGoingMb := sovHeader.GetOutGoingMiniBlockHeaderHandler(sr.chainID)
 	if check.IfNil(outGoingMb) {
 		return nil
 	}
 
-	extraSigData, found := cnsMsg.ExtraSignatures[sr.mbType.String()]
+	extraSigData, found := cnsMsg.ExtraSignatures[sr.chainID.String()]
 	if !found {
-		return fmt.Errorf("%w for type %s", bls.ErrExtraSigShareDataNotFound, sr.mbType.String())
+		return fmt.Errorf("%w for type %s", bls.ErrExtraSigShareDataNotFound, sr.chainID.String())
 	}
 
 	err := outGoingMb.SetAggregatedSignatureOutGoingOperations(extraSigData.AggregatedSignatureOutGoingTxData)
@@ -171,7 +171,7 @@ func (sr *sovereignSubRoundEndOutGoingTxData) GetLeaderExtraSig(header data.Head
 		return nil, fmt.Errorf("%w in sovereignSubRoundEndOutGoingTxData.GetLeaderExtraSig", errors.ErrWrongTypeAssertion)
 	}
 
-	outGoingMb := sovHeader.GetOutGoingMiniBlockHeaderHandler(int32(sr.mbType))
+	outGoingMb := sovHeader.GetOutGoingMiniBlockHeaderHandler(sr.chainID)
 	if check.IfNil(outGoingMb) {
 		return nil, nil
 	}
@@ -186,12 +186,12 @@ func (sr *sovereignSubRoundEndOutGoingTxData) AddLeaderAndAggregatedSignatures(h
 		return fmt.Errorf("%w in sovereignSubRoundEndOutGoingTxData.SetConsensusDataInHeader", errors.ErrWrongTypeAssertion)
 	}
 
-	outGoingMb := sovHeader.GetOutGoingMiniBlockHeaderHandler(int32(sr.mbType))
+	outGoingMb := sovHeader.GetOutGoingMiniBlockHeaderHandler(sr.chainID)
 	if check.IfNil(outGoingMb) {
 		return nil
 	}
 
-	keyStr := sr.mbType.String()
+	keyStr := sr.chainID.String()
 	initExtraSignatureEntry(cnsMsg, keyStr)
 
 	cnsMsg.ExtraSignatures[keyStr].AggregatedSignatureOutGoingTxData = outGoingMb.GetAggregatedSignatureOutGoingOperations()
@@ -207,7 +207,7 @@ func (sr *sovereignSubRoundEndOutGoingTxData) AddLeaderAndAggregatedSignatures(h
 
 // Identifier returns the unique id of the signer
 func (sr *sovereignSubRoundEndOutGoingTxData) Identifier() string {
-	return sr.mbType.String()
+	return sr.chainID.String()
 }
 
 // IsInterfaceNil checks if the underlying pointer is nil

--- a/consensus/spos/extraSigners/sovereignSubRoundEndExtraSigner_test.go
+++ b/consensus/spos/extraSigners/sovereignSubRoundEndExtraSigner_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/multiversx/mx-chain-core-go/core/check"
 	"github.com/multiversx/mx-chain-core-go/data/block"
+	"github.com/multiversx/mx-chain-core-go/data/sovereign/dto"
 	"github.com/stretchr/testify/require"
 
 	"github.com/multiversx/mx-chain-go/common"
@@ -19,13 +20,13 @@ func TestNewSovereignSubRoundEndOutGoingTxData(t *testing.T) {
 	t.Parallel()
 
 	t.Run("nil signing handler, should return error", func(t *testing.T) {
-		sovSigHandler, err := NewSovereignSubRoundEndExtraSigner(nil, block.OutGoingMbDeposit, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
+		sovSigHandler, err := NewSovereignSubRoundEndExtraSigner(nil, dto.MVX, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
 		require.Equal(t, spos.ErrNilSigningHandler, err)
 		require.True(t, check.IfNil(sovSigHandler))
 	})
 
 	t.Run("should work", func(t *testing.T) {
-		sovSigHandler, err := NewSovereignSubRoundEndExtraSigner(&cnsTest.SigningHandlerStub{}, block.OutGoingMbDeposit, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
+		sovSigHandler, err := NewSovereignSubRoundEndExtraSigner(&cnsTest.SigningHandlerStub{}, dto.MVX, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
 		require.Nil(t, err)
 		require.False(t, sovSigHandler.IsInterfaceNil())
 	})
@@ -42,6 +43,7 @@ func TestSovereignSubRoundEndOutGoingTxData_VerifyAggregatedSignatures(t *testin
 		},
 		OutGoingMiniBlockHeaders: []*block.OutGoingMiniBlockHeader{
 			{
+				ChainID:                dto.MVX,
 				OutGoingOperationsHash: outGoingOpHash,
 			},
 		},
@@ -59,7 +61,7 @@ func TestSovereignSubRoundEndOutGoingTxData_VerifyAggregatedSignatures(t *testin
 			return nil
 		},
 	}
-	sovSigHandler, _ := NewSovereignSubRoundEndExtraSigner(signingHandler, block.OutGoingMbDeposit, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
+	sovSigHandler, _ := NewSovereignSubRoundEndExtraSigner(signingHandler, dto.MVX, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
 
 	t.Run("invalid header type, should return error", func(t *testing.T) {
 		err := sovSigHandler.VerifyAggregatedSignatures(expectedBitMap, sovHdr.Header)
@@ -96,6 +98,7 @@ func TestSovereignSubRoundEndOutGoingTxData_AggregateSignatures(t *testing.T) {
 		},
 		OutGoingMiniBlockHeaders: []*block.OutGoingMiniBlockHeader{
 			{
+				ChainID:                dto.MVX,
 				OutGoingOperationsHash: []byte("hash"),
 			},
 		},
@@ -117,7 +120,7 @@ func TestSovereignSubRoundEndOutGoingTxData_AggregateSignatures(t *testing.T) {
 			return nil
 		},
 	}
-	sovSigHandler, _ := NewSovereignSubRoundEndExtraSigner(signingHandler, block.OutGoingMbDeposit, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
+	sovSigHandler, _ := NewSovereignSubRoundEndExtraSigner(signingHandler, dto.MVX, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
 	result, err := sovSigHandler.AggregateAndSetSignatures(expectedBitMap, sovHdr)
 	require.Nil(t, err)
 	require.Equal(t, aggregatedSig, result)
@@ -134,12 +137,13 @@ func TestSovereignSubRoundEndOutGoingTxData_SeAggregatedSignatureInHeader(t *tes
 		},
 		OutGoingMiniBlockHeaders: []*block.OutGoingMiniBlockHeader{
 			{
+				ChainID:                dto.MVX,
 				OutGoingOperationsHash: outGoingOpHash,
 			},
 		},
 	}
 
-	sovSigHandler, _ := NewSovereignSubRoundEndExtraSigner(&cnsTest.SigningHandlerStub{}, block.OutGoingMbDeposit, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
+	sovSigHandler, _ := NewSovereignSubRoundEndExtraSigner(&cnsTest.SigningHandlerStub{}, dto.MVX, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
 
 	t.Run("invalid header type, should return error", func(t *testing.T) {
 		err := sovSigHandler.SetAggregatedSignatureInHeader(sovHdr.Header, aggregatedSig)
@@ -163,6 +167,7 @@ func TestSovereignSubRoundEndOutGoingTxData_SeAggregatedSignatureInHeader(t *tes
 			},
 			OutGoingMiniBlockHeaders: []*block.OutGoingMiniBlockHeader{
 				{
+					ChainID:                               dto.MVX,
 					OutGoingOperationsHash:                outGoingOpHash,
 					AggregatedSignatureOutGoingOperations: aggregatedSig,
 				},
@@ -183,6 +188,7 @@ func TestSovereignSubRoundEndOutGoingTxData_SignAndSetLeaderSignature(t *testing
 		},
 		OutGoingMiniBlockHeaders: []*block.OutGoingMiniBlockHeader{
 			{
+				ChainID:                               dto.MVX,
 				OutGoingOperationsHash:                outGoingOpHash,
 				AggregatedSignatureOutGoingOperations: aggregatedSig,
 			},
@@ -202,7 +208,7 @@ func TestSovereignSubRoundEndOutGoingTxData_SignAndSetLeaderSignature(t *testing
 		},
 	}
 
-	sovSigHandler, _ := NewSovereignSubRoundEndExtraSigner(signingHandler, block.OutGoingMbDeposit, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
+	sovSigHandler, _ := NewSovereignSubRoundEndExtraSigner(signingHandler, dto.MVX, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
 
 	t.Run("invalid header type, should return error", func(t *testing.T) {
 		err := sovSigHandler.SignAndSetLeaderSignature(sovHdr.Header, expectedLeaderPubKey)
@@ -228,6 +234,7 @@ func TestSovereignSubRoundEndOutGoingTxData_SignAndSetLeaderSignature(t *testing
 			},
 			OutGoingMiniBlockHeaders: []*block.OutGoingMiniBlockHeader{
 				{
+					ChainID:                               dto.MVX,
 					OutGoingOperationsHash:                outGoingOpHash,
 					AggregatedSignatureOutGoingOperations: aggregatedSig,
 					LeaderSignatureOutGoingOperations:     expectedLeaderSig,
@@ -249,6 +256,7 @@ func TestSovereignSubRoundEndOutGoingTxData_SignAndSetLeaderSignatureInAndromeda
 		},
 		OutGoingMiniBlockHeaders: []*block.OutGoingMiniBlockHeader{
 			{
+				ChainID:                               dto.MVX,
 				OutGoingOperationsHash:                outGoingOpHash,
 				AggregatedSignatureOutGoingOperations: aggregatedSig,
 			},
@@ -270,7 +278,7 @@ func TestSovereignSubRoundEndOutGoingTxData_SignAndSetLeaderSignatureInAndromeda
 
 	sovSigHandler, _ := NewSovereignSubRoundEndExtraSigner(
 		signingHandler,
-		block.OutGoingMbDeposit,
+		dto.MVX,
 		enableEpochsHandlerMock.NewEnableEpochsHandlerStub(common.AndromedaFlag),
 	)
 
@@ -284,6 +292,7 @@ func TestSovereignSubRoundEndOutGoingTxData_SignAndSetLeaderSignatureInAndromeda
 		},
 		OutGoingMiniBlockHeaders: []*block.OutGoingMiniBlockHeader{
 			{
+				ChainID:                               dto.MVX,
 				OutGoingOperationsHash:                outGoingOpHash,
 				AggregatedSignatureOutGoingOperations: aggregatedSig,
 				LeaderSignatureOutGoingOperations:     expectedLeaderSig,
@@ -299,7 +308,7 @@ func TestSovereignSubRoundEndOutGoingTxData_HaveConsensusHeaderWithFullInfo(t *t
 	leaderSig := []byte("leaderSig")
 	cnsMsg := &consensus.Message{
 		ExtraSignatures: map[string]*consensus.ExtraSignatureData{
-			block.OutGoingMbDeposit.String(): {
+			dto.MVX.String(): {
 				AggregatedSignatureOutGoingTxData: aggregatedSig,
 				LeaderSignatureOutGoingTxData:     leaderSig,
 			},
@@ -314,12 +323,13 @@ func TestSovereignSubRoundEndOutGoingTxData_HaveConsensusHeaderWithFullInfo(t *t
 		},
 		OutGoingMiniBlockHeaders: []*block.OutGoingMiniBlockHeader{
 			{
+				ChainID:                dto.MVX,
 				OutGoingOperationsHash: outGoingOpHash,
 			},
 		},
 	}
 
-	sovSigHandler, _ := NewSovereignSubRoundEndExtraSigner(&cnsTest.SigningHandlerStub{}, block.OutGoingMbDeposit, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
+	sovSigHandler, _ := NewSovereignSubRoundEndExtraSigner(&cnsTest.SigningHandlerStub{}, dto.MVX, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
 
 	t.Run("invalid header type, should return error", func(t *testing.T) {
 		err := sovSigHandler.SetConsensusDataInHeader(sovHdr.Header, cnsMsg)
@@ -344,6 +354,7 @@ func TestSovereignSubRoundEndOutGoingTxData_HaveConsensusHeaderWithFullInfo(t *t
 			},
 			OutGoingMiniBlockHeaders: []*block.OutGoingMiniBlockHeader{
 				{
+					ChainID:                               dto.MVX,
 					OutGoingOperationsHash:                outGoingOpHash,
 					AggregatedSignatureOutGoingOperations: aggregatedSig,
 					LeaderSignatureOutGoingOperations:     leaderSig,
@@ -368,6 +379,7 @@ func TestSovereignSubRoundEndOutGoingTxData_AddLeaderAndAggregatedSignatures(t *
 		},
 		OutGoingMiniBlockHeaders: []*block.OutGoingMiniBlockHeader{
 			{
+				ChainID:                               dto.MVX,
 				OutGoingOperationsHash:                outGoingOpHash,
 				AggregatedSignatureOutGoingOperations: aggregatedSig,
 				LeaderSignatureOutGoingOperations:     leaderSig,
@@ -375,7 +387,7 @@ func TestSovereignSubRoundEndOutGoingTxData_AddLeaderAndAggregatedSignatures(t *
 		},
 	}
 
-	sovSigHandler, _ := NewSovereignSubRoundEndExtraSigner(&cnsTest.SigningHandlerStub{}, block.OutGoingMbDeposit, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
+	sovSigHandler, _ := NewSovereignSubRoundEndExtraSigner(&cnsTest.SigningHandlerStub{}, dto.MVX, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
 
 	t.Run("invalid header type, should return error", func(t *testing.T) {
 		err := sovSigHandler.AddLeaderAndAggregatedSignatures(sovHdr.Header, cnsMsg)
@@ -395,7 +407,7 @@ func TestSovereignSubRoundEndOutGoingTxData_AddLeaderAndAggregatedSignatures(t *
 		require.Nil(t, err)
 		require.Equal(t, &consensus.Message{
 			ExtraSignatures: map[string]*consensus.ExtraSignatureData{
-				block.OutGoingMbDeposit.String(): {
+				dto.MVX.String(): {
 					AggregatedSignatureOutGoingTxData: aggregatedSig,
 					LeaderSignatureOutGoingTxData:     leaderSig,
 				},
@@ -406,6 +418,6 @@ func TestSovereignSubRoundEndOutGoingTxData_AddLeaderAndAggregatedSignatures(t *
 
 func TestSovereignSubRoundEndOutGoingTxData_Identifier(t *testing.T) {
 	t.Parallel()
-	sovSigHandler, _ := NewSovereignSubRoundEndExtraSigner(&cnsTest.SigningHandlerStub{}, block.OutGoingMbDeposit, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
-	require.Equal(t, block.OutGoingMbDeposit.String(), sovSigHandler.Identifier())
+	sovSigHandler, _ := NewSovereignSubRoundEndExtraSigner(&cnsTest.SigningHandlerStub{}, dto.MVX, &enableEpochsHandlerMock.EnableEpochsHandlerStub{})
+	require.Equal(t, dto.MVX.String(), sovSigHandler.Identifier())
 }

--- a/consensus/spos/extraSigners/sovereignSubRoundSignatureExtraSigner.go
+++ b/consensus/spos/extraSigners/sovereignSubRoundSignatureExtraSigner.go
@@ -5,8 +5,6 @@ import (
 
 	"github.com/multiversx/mx-chain-core-go/core/check"
 	"github.com/multiversx/mx-chain-core-go/data"
-	"github.com/multiversx/mx-chain-core-go/data/block"
-
 	"github.com/multiversx/mx-chain-go/consensus"
 	"github.com/multiversx/mx-chain-go/consensus/spos"
 	"github.com/multiversx/mx-chain-go/errors"
@@ -14,13 +12,13 @@ import (
 
 type sovereignSubRoundSignatureOutGoingTxData struct {
 	signingHandler consensus.SigningHandler
-	mbType         block.OutGoingMBType
+	chainID        int32dd
 }
 
 // NewSovereignSubRoundSignatureExtraSigner creates a new signer for sovereign outgoing mini blocks in signature subround
 func NewSovereignSubRoundSignatureExtraSigner(
 	signingHandler consensus.SigningHandler,
-	mbType block.OutGoingMBType,
+	chainID int32,
 ) (*sovereignSubRoundSignatureOutGoingTxData, error) {
 	if check.IfNil(signingHandler) {
 		return nil, spos.ErrNilSigningHandler
@@ -28,7 +26,7 @@ func NewSovereignSubRoundSignatureExtraSigner(
 
 	return &sovereignSubRoundSignatureOutGoingTxData{
 		signingHandler: signingHandler,
-		mbType:         mbType,
+		chainID:        chainID,
 	}, nil
 }
 
@@ -43,7 +41,7 @@ func (sr *sovereignSubRoundSignatureOutGoingTxData) CreateSignatureShare(
 		return nil, fmt.Errorf("%w in sovereignSubRoundSignatureOutGoingTxData.CreateSignatureShare", errors.ErrWrongTypeAssertion)
 	}
 
-	outGoingMBHeader := sovChainHeader.GetOutGoingMiniBlockHeaderHandler(int32(sr.mbType))
+	outGoingMBHeader := sovChainHeader.GetOutGoingMiniBlockHeaderHandler(sr.chainID)
 	if check.IfNil(outGoingMBHeader) {
 		return make([]byte, 0), nil
 	}

--- a/consensus/spos/extraSigners/sovereignSubRoundSignatureExtraSigner.go
+++ b/consensus/spos/extraSigners/sovereignSubRoundSignatureExtraSigner.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/multiversx/mx-chain-core-go/core/check"
 	"github.com/multiversx/mx-chain-core-go/data"
+	"github.com/multiversx/mx-chain-core-go/data/sovereign/dto"
 	"github.com/multiversx/mx-chain-go/consensus"
 	"github.com/multiversx/mx-chain-go/consensus/spos"
 	"github.com/multiversx/mx-chain-go/errors"
@@ -12,13 +13,13 @@ import (
 
 type sovereignSubRoundSignatureOutGoingTxData struct {
 	signingHandler consensus.SigningHandler
-	chainID        int32dd
+	chainID        dto.ChainID
 }
 
 // NewSovereignSubRoundSignatureExtraSigner creates a new signer for sovereign outgoing mini blocks in signature subround
 func NewSovereignSubRoundSignatureExtraSigner(
 	signingHandler consensus.SigningHandler,
-	chainID int32,
+	chainID dto.ChainID,
 ) (*sovereignSubRoundSignatureOutGoingTxData, error) {
 	if check.IfNil(signingHandler) {
 		return nil, spos.ErrNilSigningHandler
@@ -63,7 +64,7 @@ func (sr *sovereignSubRoundSignatureOutGoingTxData) AddSigShareToConsensusMessag
 		return nil
 
 	}
-	keyStr := sr.mbType.String()
+	keyStr := sr.chainID.String()
 	initExtraSignatureEntry(cnsMsg, keyStr)
 
 	cnsMsg.ExtraSignatures[keyStr].SignatureShareOutGoingTxData = sigShare
@@ -76,7 +77,7 @@ func (sr *sovereignSubRoundSignatureOutGoingTxData) StoreSignatureShare(index ui
 		return errors.ErrNilConsensusMessage
 	}
 
-	if extraSigData, found := cnsMsg.ExtraSignatures[sr.mbType.String()]; found {
+	if extraSigData, found := cnsMsg.ExtraSignatures[sr.chainID.String()]; found {
 		return sr.signingHandler.StoreSignatureShare(index, extraSigData.SignatureShareOutGoingTxData)
 	}
 
@@ -85,7 +86,7 @@ func (sr *sovereignSubRoundSignatureOutGoingTxData) StoreSignatureShare(index ui
 
 // Identifier returns the unique id of the signer
 func (sr *sovereignSubRoundSignatureOutGoingTxData) Identifier() string {
-	return sr.mbType.String()
+	return sr.chainID.String()
 }
 
 // IsInterfaceNil checks if the underlying pointer is nil

--- a/consensus/spos/extraSigners/sovereignSubRoundSignatureExtraSigner_test.go
+++ b/consensus/spos/extraSigners/sovereignSubRoundSignatureExtraSigner_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/multiversx/mx-chain-core-go/core/check"
 	"github.com/multiversx/mx-chain-core-go/data/block"
+	"github.com/multiversx/mx-chain-core-go/data/sovereign/dto"
 	"github.com/stretchr/testify/require"
 
 	"github.com/multiversx/mx-chain-go/consensus"
@@ -17,13 +18,13 @@ func TestNewSovereignSubRoundSignatureOutGoingTxData(t *testing.T) {
 	t.Parallel()
 
 	t.Run("nil signing handler, should return error", func(t *testing.T) {
-		sovSigHandler, err := NewSovereignSubRoundSignatureExtraSigner(nil, block.OutGoingMbDeposit)
+		sovSigHandler, err := NewSovereignSubRoundSignatureExtraSigner(nil, dto.MVX)
 		require.Equal(t, spos.ErrNilSigningHandler, err)
 		require.True(t, check.IfNil(sovSigHandler))
 	})
 
 	t.Run("should work", func(t *testing.T) {
-		sovSigHandler, err := NewSovereignSubRoundSignatureExtraSigner(&cnsTest.SigningHandlerStub{}, block.OutGoingMbDeposit)
+		sovSigHandler, err := NewSovereignSubRoundSignatureExtraSigner(&cnsTest.SigningHandlerStub{}, dto.MVX)
 		require.Nil(t, err)
 		require.False(t, sovSigHandler.IsInterfaceNil())
 	})
@@ -40,6 +41,7 @@ func TestSovereignSubRoundSignatureOutGoingTxData_CreateSignatureShare(t *testin
 		},
 		OutGoingMiniBlockHeaders: []*block.OutGoingMiniBlockHeader{
 			{
+				ChainID:                dto.MVX,
 				OutGoingOperationsHash: outGoingOpHash,
 			},
 		},
@@ -60,7 +62,7 @@ func TestSovereignSubRoundSignatureOutGoingTxData_CreateSignatureShare(t *testin
 			return expectedSigShare, nil
 		},
 	}
-	sovSigHandler, _ := NewSovereignSubRoundSignatureExtraSigner(signingHandler, block.OutGoingMbDeposit)
+	sovSigHandler, _ := NewSovereignSubRoundSignatureExtraSigner(signingHandler, dto.MVX)
 
 	t.Run("invalid header type, should return error", func(t *testing.T) {
 		sigShare, err := sovSigHandler.CreateSignatureShare(sovHdr.Header, selfIndex, selfPubKey)
@@ -92,7 +94,7 @@ func TestSovereignSubRoundSignatureOutGoingTxData_AddSigShareToConsensusMessage(
 		SignatureShare: []byte("sigShare"),
 	}
 
-	sovSigHandler, _ := NewSovereignSubRoundSignatureExtraSigner(&cnsTest.SigningHandlerStub{}, block.OutGoingMbDeposit)
+	sovSigHandler, _ := NewSovereignSubRoundSignatureExtraSigner(&cnsTest.SigningHandlerStub{}, dto.MVX)
 
 	err := sovSigHandler.AddSigShareToConsensusMessage([]byte("sigShareOutGoingTxData"), nil)
 	require.Equal(t, errors.ErrNilConsensusMessage, err)
@@ -102,7 +104,7 @@ func TestSovereignSubRoundSignatureOutGoingTxData_AddSigShareToConsensusMessage(
 	require.Equal(t, &consensus.Message{
 		SignatureShare: []byte("sigShare"),
 		ExtraSignatures: map[string]*consensus.ExtraSignatureData{
-			block.OutGoingMbDeposit.String(): {
+			dto.MVX.String(): {
 				SignatureShareOutGoingTxData: []byte("sigShareOutGoingTxData"),
 			},
 		},
@@ -115,7 +117,7 @@ func TestSovereignSubRoundSignatureOutGoingTxData_StoreSignatureShare(t *testing
 	cnsMsg := &consensus.Message{
 		SignatureShare: []byte("sigShare"),
 		ExtraSignatures: map[string]*consensus.ExtraSignatureData{
-			block.OutGoingMbDeposit.String(): {
+			dto.MVX.String(): {
 				SignatureShareOutGoingTxData: []byte("sigShareOutGoingTxData"),
 			},
 		},
@@ -126,14 +128,14 @@ func TestSovereignSubRoundSignatureOutGoingTxData_StoreSignatureShare(t *testing
 	signHandler := &cnsTest.SigningHandlerStub{
 		StoreSignatureShareCalled: func(index uint16, sig []byte) error {
 			require.Equal(t, expectedIdx, index)
-			require.Equal(t, cnsMsg.ExtraSignatures[block.OutGoingMbDeposit.String()].SignatureShareOutGoingTxData, sig)
+			require.Equal(t, cnsMsg.ExtraSignatures[dto.MVX.String()].SignatureShareOutGoingTxData, sig)
 
 			wasSigStored = true
 			return nil
 		},
 	}
 
-	sovSigHandler, _ := NewSovereignSubRoundSignatureExtraSigner(signHandler, block.OutGoingMbDeposit)
+	sovSigHandler, _ := NewSovereignSubRoundSignatureExtraSigner(signHandler, dto.MVX)
 
 	err := sovSigHandler.StoreSignatureShare(expectedIdx, nil)
 	require.Equal(t, errors.ErrNilConsensusMessage, err)
@@ -146,6 +148,6 @@ func TestSovereignSubRoundSignatureOutGoingTxData_StoreSignatureShare(t *testing
 func TestSovereignSubRoundSignatureOutGoingTxData_Identifier(t *testing.T) {
 	t.Parallel()
 
-	sovSigHandler, _ := NewSovereignSubRoundSignatureExtraSigner(&cnsTest.SigningHandlerStub{}, block.OutGoingMbDeposit)
-	require.Equal(t, block.OutGoingMbDeposit.String(), sovSigHandler.Identifier())
+	sovSigHandler, _ := NewSovereignSubRoundSignatureExtraSigner(&cnsTest.SigningHandlerStub{}, dto.MVX)
+	require.Equal(t, dto.MVX.String(), sovSigHandler.Identifier())
 }

--- a/consensus/spos/extraSigners/sovereignSubRoundStartExtraSigner.go
+++ b/consensus/spos/extraSigners/sovereignSubRoundStartExtraSigner.go
@@ -2,7 +2,7 @@ package extraSigners
 
 import (
 	"github.com/multiversx/mx-chain-core-go/core/check"
-	"github.com/multiversx/mx-chain-core-go/data/block"
+	"github.com/multiversx/mx-chain-core-go/data/sovereign/dto"
 
 	"github.com/multiversx/mx-chain-go/consensus"
 	"github.com/multiversx/mx-chain-go/consensus/spos"
@@ -10,13 +10,13 @@ import (
 
 type sovereignSubRoundStartOutGoingTxData struct {
 	signingHandler consensus.SigningHandler
-	mbType         block.OutGoingMBType
+	chainID        dto.ChainID
 }
 
 // NewSovereignSubRoundStartExtraSigner creates a new signer for sovereign outgoing mb in start subround
 func NewSovereignSubRoundStartExtraSigner(
 	signingHandler consensus.SigningHandler,
-	mbType block.OutGoingMBType,
+	chainID dto.ChainID,
 ) (*sovereignSubRoundStartOutGoingTxData, error) {
 	if check.IfNil(signingHandler) {
 		return nil, spos.ErrNilSigningHandler
@@ -24,7 +24,7 @@ func NewSovereignSubRoundStartExtraSigner(
 
 	return &sovereignSubRoundStartOutGoingTxData{
 		signingHandler: signingHandler,
-		mbType:         mbType,
+		chainID:        chainID,
 	}, nil
 }
 
@@ -35,7 +35,7 @@ func (sr *sovereignSubRoundStartOutGoingTxData) Reset(pubKeys []string) error {
 
 // Identifier returns the unique id of the signer
 func (sr *sovereignSubRoundStartOutGoingTxData) Identifier() string {
-	return sr.mbType.String()
+	return sr.chainID.String()
 }
 
 // IsInterfaceNil checks if the underlying pointer is nil

--- a/consensus/spos/extraSigners/sovereignSubRoundStartExtraSigner_test.go
+++ b/consensus/spos/extraSigners/sovereignSubRoundStartExtraSigner_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/multiversx/mx-chain-core-go/core/check"
-	"github.com/multiversx/mx-chain-core-go/data/block"
+	"github.com/multiversx/mx-chain-core-go/data/sovereign/dto"
 	"github.com/stretchr/testify/require"
 
 	"github.com/multiversx/mx-chain-go/consensus/spos"
@@ -15,13 +15,13 @@ func TestNewSovereignSubRoundStartOutGoingTxData(t *testing.T) {
 	t.Parallel()
 
 	t.Run("nil signing handler, should return error", func(t *testing.T) {
-		sovSigHandler, err := NewSovereignSubRoundStartExtraSigner(nil, block.OutGoingMbDeposit)
+		sovSigHandler, err := NewSovereignSubRoundStartExtraSigner(nil, dto.MVX)
 		require.Equal(t, spos.ErrNilSigningHandler, err)
 		require.True(t, check.IfNil(sovSigHandler))
 	})
 
 	t.Run("should work", func(t *testing.T) {
-		sovSigHandler, err := NewSovereignSubRoundStartExtraSigner(&cnsTest.SigningHandlerStub{}, block.OutGoingMbDeposit)
+		sovSigHandler, err := NewSovereignSubRoundStartExtraSigner(&cnsTest.SigningHandlerStub{}, dto.MVX)
 		require.Nil(t, err)
 		require.False(t, sovSigHandler.IsInterfaceNil())
 	})
@@ -40,7 +40,7 @@ func TestSovereignSubRoundStartOutGoingTxData_Reset(t *testing.T) {
 		},
 	}
 
-	sovSigHandler, _ := NewSovereignSubRoundStartExtraSigner(sigHandler, block.OutGoingMbDeposit)
+	sovSigHandler, _ := NewSovereignSubRoundStartExtraSigner(sigHandler, dto.MVX)
 	err := sovSigHandler.Reset(expectedPubKeys)
 	require.Nil(t, err)
 	require.True(t, wasResetCalled)
@@ -49,6 +49,6 @@ func TestSovereignSubRoundStartOutGoingTxData_Reset(t *testing.T) {
 func TestSovereignSubRoundStartOutGoingTxData_Identifier(t *testing.T) {
 	t.Parallel()
 
-	sovSigHandler, _ := NewSovereignSubRoundStartExtraSigner(&cnsTest.SigningHandlerStub{}, block.OutGoingMbDeposit)
-	require.Equal(t, block.OutGoingMbDeposit.String(), sovSigHandler.Identifier())
+	sovSigHandler, _ := NewSovereignSubRoundStartExtraSigner(&cnsTest.SigningHandlerStub{}, dto.MVX)
+	require.Equal(t, dto.MVX.String(), sovSigHandler.Identifier())
 }

--- a/factory/runType/sovereignRunTypeComponents.go
+++ b/factory/runType/sovereignRunTypeComponents.go
@@ -5,7 +5,7 @@ import (
 	"math/big"
 	"time"
 
-	dataBlock "github.com/multiversx/mx-chain-core-go/data/block"
+	"github.com/multiversx/mx-chain-core-go/data/sovereign/dto"
 
 	"github.com/multiversx/mx-chain-go/config"
 	"github.com/multiversx/mx-chain-go/consensus"
@@ -289,38 +289,37 @@ func (rcf *sovereignRunTypeComponentsFactory) createOutGoingTxDataSigners() (bls
 	signRoundExtraSignersHolder := holders.NewSubRoundSignatureExtraSignersHolder()
 	endRoundExtraSignersHolder := holders.NewSubRoundEndExtraSignersHolder()
 
-	// TODO: Marius C: MX-17260 Here we should prepare code to iterate through chains
-	//for _, mbTypeValue := range dataBlock.OutGoingMBType_value {
-	mbType := dataBlock.OutGoingMBType(0)
-	extraSignerHandler := rcf.cryptoComponents.ConsensusSigningHandler().ShallowClone()
+	// TODO: Marius C: MX-17260 Here we should iterate through the ordered chain id func fron feat/multi-chain
+	for chainID := range dto.ValidChains {
+		extraSignerHandler := rcf.cryptoComponents.ConsensusSigningHandler().ShallowClone()
 
-	startRoundExtraSignerOutGoingTx, err := extraSigners.NewSovereignSubRoundStartExtraSigner(extraSignerHandler, mbType)
-	if err != nil {
-		return nil, err
-	}
-	err = startRoundExtraSignersHolder.RegisterExtraSigningHandler(startRoundExtraSignerOutGoingTx)
-	if err != nil {
-		return nil, err
-	}
+		startRoundExtraSignerOutGoingTx, err := extraSigners.NewSovereignSubRoundStartExtraSigner(extraSignerHandler, chainID)
+		if err != nil {
+			return nil, err
+		}
+		err = startRoundExtraSignersHolder.RegisterExtraSigningHandler(startRoundExtraSignerOutGoingTx)
+		if err != nil {
+			return nil, err
+		}
 
-	signRoundExtraSignerOutGoingTx, err := extraSigners.NewSovereignSubRoundSignatureExtraSigner(extraSignerHandler, mbType)
-	if err != nil {
-		return nil, err
-	}
-	err = signRoundExtraSignersHolder.RegisterExtraSigningHandler(signRoundExtraSignerOutGoingTx)
-	if err != nil {
-		return nil, err
-	}
+		signRoundExtraSignerOutGoingTx, err := extraSigners.NewSovereignSubRoundSignatureExtraSigner(extraSignerHandler, chainID)
+		if err != nil {
+			return nil, err
+		}
+		err = signRoundExtraSignersHolder.RegisterExtraSigningHandler(signRoundExtraSignerOutGoingTx)
+		if err != nil {
+			return nil, err
+		}
 
-	endRoundExtraSignerOutGoingTx, err := extraSigners.NewSovereignSubRoundEndExtraSigner(extraSignerHandler, mbType, rcf.coreComponents.EnableEpochsHandler())
-	if err != nil {
-		return nil, err
+		endRoundExtraSignerOutGoingTx, err := extraSigners.NewSovereignSubRoundEndExtraSigner(extraSignerHandler, chainID, rcf.coreComponents.EnableEpochsHandler())
+		if err != nil {
+			return nil, err
+		}
+		err = endRoundExtraSignersHolder.RegisterExtraSigningHandler(endRoundExtraSignerOutGoingTx)
+		if err != nil {
+			return nil, err
+		}
 	}
-	err = endRoundExtraSignersHolder.RegisterExtraSigningHandler(endRoundExtraSignerOutGoingTx)
-	if err != nil {
-		return nil, err
-	}
-	//}
 
 	return holders.NewExtraSignersHolder(
 		startRoundExtraSignersHolder,

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/multiversx/mx-chain-go
 
 replace (
-	github.com/multiversx/mx-chain-core-go => github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20251022095915-f9ac02331b58
+	github.com/multiversx/mx-chain-core-go => github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20251023103300-a4674eb8cfa2
 	github.com/multiversx/mx-chain-es-indexer-go => github.com/multiversx/mx-chain-es-indexer-sovereign-go v1.7.17-0.20250826102827-1b5ebecb30da
 	github.com/multiversx/mx-chain-vm-common-go => github.com/multiversx/mx-chain-vm-common-sovereign-go v1.5.17-0.20250715144941-88820f3a7c28
 )

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/multiversx/mx-chain-go
 
 replace (
-	github.com/multiversx/mx-chain-core-go => github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20251023103300-a4674eb8cfa2
+	github.com/multiversx/mx-chain-core-go => github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20251023112952-769bc6df03c5
 	github.com/multiversx/mx-chain-es-indexer-go => github.com/multiversx/mx-chain-es-indexer-sovereign-go v1.7.17-0.20250826102827-1b5ebecb30da
 	github.com/multiversx/mx-chain-vm-common-go => github.com/multiversx/mx-chain-vm-common-sovereign-go v1.5.17-0.20250715144941-88820f3a7c28
 )

--- a/go.sum
+++ b/go.sum
@@ -405,8 +405,8 @@ github.com/multiversx/concurrent-map v0.1.4 h1:hdnbM8VE4b0KYJaGY5yJS2aNIW9TFFsUY
 github.com/multiversx/concurrent-map v0.1.4/go.mod h1:8cWFRJDOrWHOTNSqgYCUvwT7c7eFQ4U2vKMOp4A/9+o=
 github.com/multiversx/mx-chain-communication-go v1.3.0 h1:ziNM1dRuiR/7al2L/jGEA/a/hjurtJ/HEqgazHNt9P8=
 github.com/multiversx/mx-chain-communication-go v1.3.0/go.mod h1:gDVWn6zUW6aCN1YOm/FbbT5MUmhgn/L1Rmpl8EoH3Yg=
-github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20251023103300-a4674eb8cfa2 h1:yWmYYxXsHWipjgOanX3NQqkTKjaUlA2zMNpXaK9I61A=
-github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20251023103300-a4674eb8cfa2/go.mod h1:8VKRU04HXXGELmzoIh9x2oYtWEatOZtgd8Mou6rAT8I=
+github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20251023112952-769bc6df03c5 h1:4i5tyqdCBV49/KX0whzzqm2E5y+s3rUsHuQP3aVL8Hc=
+github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20251023112952-769bc6df03c5/go.mod h1:8VKRU04HXXGELmzoIh9x2oYtWEatOZtgd8Mou6rAT8I=
 github.com/multiversx/mx-chain-crypto-go v1.3.0 h1:0eK2bkDOMi8VbSPrB1/vGJSYT81IBtfL4zw+C4sWe/k=
 github.com/multiversx/mx-chain-crypto-go v1.3.0/go.mod h1:nPIkxxzyTP8IquWKds+22Q2OJ9W7LtusC7cAosz7ojM=
 github.com/multiversx/mx-chain-es-indexer-sovereign-go v1.7.17-0.20250826102827-1b5ebecb30da h1:7CAv12kiimjdv+odZGJ262EREeyi1/e+fBwJqPWGst0=

--- a/go.sum
+++ b/go.sum
@@ -405,8 +405,8 @@ github.com/multiversx/concurrent-map v0.1.4 h1:hdnbM8VE4b0KYJaGY5yJS2aNIW9TFFsUY
 github.com/multiversx/concurrent-map v0.1.4/go.mod h1:8cWFRJDOrWHOTNSqgYCUvwT7c7eFQ4U2vKMOp4A/9+o=
 github.com/multiversx/mx-chain-communication-go v1.3.0 h1:ziNM1dRuiR/7al2L/jGEA/a/hjurtJ/HEqgazHNt9P8=
 github.com/multiversx/mx-chain-communication-go v1.3.0/go.mod h1:gDVWn6zUW6aCN1YOm/FbbT5MUmhgn/L1Rmpl8EoH3Yg=
-github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20251022095915-f9ac02331b58 h1:eSaK55GVwmU4/MPtR/iwhuABDzyrzU9deouec9vy9cc=
-github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20251022095915-f9ac02331b58/go.mod h1:8VKRU04HXXGELmzoIh9x2oYtWEatOZtgd8Mou6rAT8I=
+github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20251023103300-a4674eb8cfa2 h1:yWmYYxXsHWipjgOanX3NQqkTKjaUlA2zMNpXaK9I61A=
+github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20251023103300-a4674eb8cfa2/go.mod h1:8VKRU04HXXGELmzoIh9x2oYtWEatOZtgd8Mou6rAT8I=
 github.com/multiversx/mx-chain-crypto-go v1.3.0 h1:0eK2bkDOMi8VbSPrB1/vGJSYT81IBtfL4zw+C4sWe/k=
 github.com/multiversx/mx-chain-crypto-go v1.3.0/go.mod h1:nPIkxxzyTP8IquWKds+22Q2OJ9W7LtusC7cAosz7ojM=
 github.com/multiversx/mx-chain-es-indexer-sovereign-go v1.7.17-0.20250826102827-1b5ebecb30da h1:7CAv12kiimjdv+odZGJ262EREeyi1/e+fBwJqPWGst0=

--- a/process/block/baseProcess_test.go
+++ b/process/block/baseProcess_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data/block"
 	"github.com/multiversx/mx-chain-core-go/data/rewardTx"
 	"github.com/multiversx/mx-chain-core-go/data/scheduled"
+	"github.com/multiversx/mx-chain-core-go/data/sovereign/dto"
 	"github.com/multiversx/mx-chain-core-go/data/transaction"
 	"github.com/multiversx/mx-chain-core-go/data/typeConverters/uint64ByteSlice"
 	"github.com/multiversx/mx-chain-core-go/hashing"
@@ -3416,11 +3417,11 @@ func TestBaseProcessor_DisplayHeader(t *testing.T) {
 		require.Equal(t, 23, len(lines))
 
 		proof.ExtraSignatures = map[string]*block.ExtraSignatureData{
-			block.OutGoingMbDeposit.String(): {
+			dto.MVX.String(): {
 				AggregatedSignature: []byte("aggSig1"),
 				LeaderSignature:     []byte("leaderSig1"),
 			},
-			block.OutGoingMbChangeValidatorSet.String(): {
+			dto.ETH.String(): {
 				AggregatedSignature: []byte("aggSig2"),
 				LeaderSignature:     []byte("leaderSig2"),
 			},

--- a/process/block/displayBlock.go
+++ b/process/block/displayBlock.go
@@ -245,12 +245,11 @@ func (txc *transactionCounter) displayOutGoingTxData(
 		"Hash",
 		logger.DisplayByteSlice(outGoingMb.GetHash())}),
 	)
-	// TODO: Marius C: MX-17260 Here we should output the chain id
-	//lines = append(lines, display.NewLineData(false, []string{
-	//	"",
-	//	"Type",
-	//	block.OutGoingMBType(outGoingMb.GetOutGoingMBTypeInt32()).String()}),
-	//)
+	lines = append(lines, display.NewLineData(false, []string{
+		"",
+		"Chain",
+		outGoingMb.GetChainID().String()}),
+	)
 	lines = append(lines, display.NewLineData(false, []string{
 		"",
 		"OutGoingTxDataHash",

--- a/process/block/displayBlock_test.go
+++ b/process/block/displayBlock_test.go
@@ -51,11 +51,10 @@ func createDisplayLinesForOutGoingMb(outGoingMb *block.OutGoingMiniBlockHeader) 
 			Values:              []string{"OutGoing mini block header", "Hash", hex.EncodeToString(outGoingMb.GetHash())},
 			HorizontalRuleAfter: false,
 		},
-		// TODO: Marius C: MX-17260 Here we should only output the chain id
-		//{
-		//	Values:              []string{"", "Type", block.OutGoingMBType(outGoingMb.GetOutGoingMBTypeInt32()).String()},
-		//	HorizontalRuleAfter: false,
-		//},
+		{
+			Values:              []string{"", "Chain", outGoingMb.ChainID.String()},
+			HorizontalRuleAfter: false,
+		},
 		{
 			Values:              []string{"", "OutGoingTxDataHash", hex.EncodeToString(outGoingMb.GetOutGoingOperationsHash())},
 			HorizontalRuleAfter: false,

--- a/process/block/sovereign/incomingHeader/dto/dto.go
+++ b/process/block/sovereign/incomingHeader/dto/dto.go
@@ -74,7 +74,7 @@ type EventsResult struct {
 
 // OutGoingOperation defines an outgoing operation
 type OutGoingOperation struct {
-	Nonce  uint64
-	MBType block.OutGoingMBType
-	Data   []byte
+	Nonce uint64
+	Type  block.OutGoingOpType
+	Data  []byte
 }

--- a/process/block/sovereign/outgoingOperations.go
+++ b/process/block/sovereign/outgoingOperations.go
@@ -20,9 +20,9 @@ import (
 
 type opFormatterData struct {
 	handler OperationFormatter
-	mbType  block.OutGoingMBType
+	opType  block.OutGoingOpType
 }
-type createOpFormatterHandler func(args ArgsOutgoingOperations) (OperationFormatter, block.OutGoingMBType, error)
+type createOpFormatterHandler func(args ArgsOutgoingOperations) (OperationFormatter, block.OutGoingOpType, error)
 
 const (
 	topicIDDeposit          = "deposit"
@@ -149,19 +149,19 @@ func createOpFormatterHandlers(subscribedEvents map[string]struct{}, args ArgsOu
 	}
 
 	availableHandlers := map[string]createOpFormatterHandler{
-		topicIDDeposit: func(args ArgsOutgoingOperations) (OperationFormatter, block.OutGoingMBType, error) {
+		topicIDDeposit: func(args ArgsOutgoingOperations) (OperationFormatter, block.OutGoingOpType, error) {
 			opFormatter, err := operationFormatters.NewDepositOpFormatter(args.DataCodec, args.TopicsChecker)
-			return opFormatter, block.OutGoingMbDeposit, err
+			return opFormatter, block.OutGoingOpDeposit, err
 		},
-		topicIDRegisterToken: func(args ArgsOutgoingOperations) (OperationFormatter, block.OutGoingMBType, error) {
+		topicIDRegisterToken: func(args ArgsOutgoingOperations) (OperationFormatter, block.OutGoingOpType, error) {
 			opFormatter, err := operationFormatters.NewRegisterTokenOpFormatter(args.DataCodec)
-			return opFormatter, block.OutGoingMBRegisterToken, err
+			return opFormatter, block.OutGoingOpRegisterToken, err
 		},
-		topicIDRegisterBlsKey: func(args ArgsOutgoingOperations) (OperationFormatter, block.OutGoingMBType, error) {
-			return blsKeyOpFormatter, block.OutGoingMBRegisterBlsKey, nil
+		topicIDRegisterBlsKey: func(args ArgsOutgoingOperations) (OperationFormatter, block.OutGoingOpType, error) {
+			return blsKeyOpFormatter, block.OutGoingOpRegisterBlsKey, nil
 		},
-		topicIDUnRegisterBlsKey: func(args ArgsOutgoingOperations) (OperationFormatter, block.OutGoingMBType, error) {
-			return blsKeyOpFormatter, block.OutGoingMBUnRegisterBlsKey, nil
+		topicIDUnRegisterBlsKey: func(args ArgsOutgoingOperations) (OperationFormatter, block.OutGoingOpType, error) {
+			return blsKeyOpFormatter, block.OutGoingOpUnRegisterBlsKey, nil
 		},
 	}
 
@@ -197,14 +197,14 @@ func addHandlerIfSubscribed(
 		return nil
 	}
 
-	opHandler, mbType, err := createOpFormatterHandlerFunc(args)
+	opHandler, opType, err := createOpFormatterHandlerFunc(args)
 	if err != nil {
 		return err
 	}
 
 	allHandlers[id] = opFormatterData{
 		handler: opHandler,
-		mbType:  mbType,
+		opType:  opType,
 	}
 
 	delete(subscribedEvents, id)
@@ -292,8 +292,8 @@ func (op *outgoingOperations) getOperationData(event data.EventHandler) (*dto.Ou
 
 	opData, err := opFormatter.handler.CreateOperationData(event)
 	return &dto.OutGoingOperation{
-		MBType: opFormatter.mbType,
-		Data:   opData,
+		Type: opFormatter.opType,
+		Data: opData,
 	}, err
 }
 

--- a/process/block/sovereign/outgoingOperations_test.go
+++ b/process/block/sovereign/outgoingOperations_test.go
@@ -384,8 +384,8 @@ func TestOutgoingOperations_CreateOutgoingTxData(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, []*dto.OutGoingOperation{
 		{
-			MBType: block.OutGoingMbDeposit,
-			Data:   operationBytes,
+			Type: block.OutGoingOpDeposit,
+			Data: operationBytes,
 		},
 	}, outgoingTxData)
 }
@@ -468,8 +468,8 @@ func TestOutgoingOperations_CreateOutgoingTxScCall(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, []*dto.OutGoingOperation{
 		{
-			MBType: block.OutGoingMbDeposit,
-			Data:   operationBytes,
+			Type: block.OutGoingOpDeposit,
+			Data: operationBytes,
 		},
 	}, outgoingTxData)
 }

--- a/process/block/sovereignChainBlock.go
+++ b/process/block/sovereignChainBlock.go
@@ -12,6 +12,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-core-go/data/block"
 	sovCore "github.com/multiversx/mx-chain-core-go/data/sovereign"
+	dtoSov "github.com/multiversx/mx-chain-core-go/data/sovereign/dto"
 	"github.com/multiversx/mx-chain-core-go/data/transaction"
 	"github.com/multiversx/mx-chain-core-go/hashing"
 	"github.com/multiversx/mx-chain-go/process/block/sovereign/incomingHeader/dto"
@@ -1273,6 +1274,8 @@ func (scbp *sovereignChainBlockProcessor) computeEpochChangeOutGoingMBHeaderAndH
 	}
 
 	outGoingMbHeader := &block.OutGoingMiniBlockHeader{
+		// TODO: Marius C: MX-17260 remove this hard codded chain id
+		ChainID:                dtoSov.MVX,
 		Hash:                   outGoingMbHash,
 		OutGoingOperationsHash: outGoingOperationsHash,
 	}
@@ -1296,6 +1299,8 @@ func (scbp *sovereignChainBlockProcessor) computeReceivedOutGoingMBHeaderHash(
 	}
 
 	outGoingMBHeader := &block.OutGoingMiniBlockHeader{
+		// TODO: Marius C: MX-17260 remove this hard codded chain id
+		ChainID:                dtoSov.MVX,
 		Hash:                   receivedOutGoingMB[0].GetHash(),
 		OutGoingOperationsHash: receivedOutGoingMB[0].GetOutGoingOperationsHash(),
 	}
@@ -1738,6 +1743,8 @@ func (scbp *sovereignChainBlockProcessor) setOutGoingMiniBlock(
 	}
 
 	outGoingMbHeader := &block.OutGoingMiniBlockHeader{
+		// TODO: Marius C: MX-17260 remove this hard codded chain id
+		ChainID:                dtoSov.MVX,
 		Hash:                   outGoingMbHash,
 		OutGoingOperationsHash: outGoingOperationsHash,
 	}

--- a/process/block/sovereignChainBlock.go
+++ b/process/block/sovereignChainBlock.go
@@ -384,8 +384,8 @@ func (scbp *sovereignChainBlockProcessor) createAndSetEpochStartOutGoingOperatio
 		header,
 		[]*dto.OutGoingOperation{
 			{
-				MBType: block.OutGoingMbChangeValidatorSet,
-				Data:   outGoingOperationChangeValidatorSet,
+				Type: block.OutGoingOpChangeValidatorSet,
+				Data: outGoingOperationChangeValidatorSet,
 			},
 		},
 		body,
@@ -1261,8 +1261,8 @@ func (scbp *sovereignChainBlockProcessor) computeEpochChangeOutGoingMBHeaderAndH
 		header,
 		[]*dto.OutGoingOperation{
 			{
-				MBType: block.OutGoingMbChangeValidatorSet,
-				Data:   outGoingOperationChangeValidatorSet,
+				Type: block.OutGoingOpChangeValidatorSet,
+				Data: outGoingOperationChangeValidatorSet,
 			},
 		},
 	)
@@ -1292,7 +1292,7 @@ func (scbp *sovereignChainBlockProcessor) computeReceivedOutGoingMBHeaderHash(
 	receivedOutGoingMB := header.GetOutGoingMiniBlockHeaderHandlers()
 	if len(receivedOutGoingMB) == 0 {
 		return nil, fmt.Errorf("%w for %s in func computeReceivedOutGoingMBHeaderHash",
-			data.ErrNilOutGoingMiniBlockHeaderHandlerProvided, block.OutGoingMbChangeValidatorSet.String())
+			data.ErrNilOutGoingMiniBlockHeaderHandlerProvided, block.OutGoingOpChangeValidatorSet.String())
 	}
 
 	outGoingMBHeader := &block.OutGoingMiniBlockHeader{
@@ -1677,7 +1677,7 @@ func (scbp *sovereignChainBlockProcessor) createOutGoingMiniBlockData(
 		aggregatedOutGoingOperations = append(aggregatedOutGoingOperations, outGoingOpHash...)
 
 		outGoingOpData := &sovCore.OutGoingOperation{
-			Type: int32(outGoingOp.MBType),
+			Type: int32(outGoingOp.Type),
 			Hash: outGoingOpHash,
 			Data: outGoingOp.Data,
 		}

--- a/process/block/sovereignChainBlock_test.go
+++ b/process/block/sovereignChainBlock_test.go
@@ -317,12 +317,12 @@ func TestSovereignChainBlockProcessor_createAndSetOutGoingMiniBlockTxs(t *testin
 			require.Equal(t, expectedLogs, logs)
 			return []*dto.OutGoingOperation{
 				{
-					MBType: block.OutGoingMbDeposit,
-					Data:   bridgeOp1,
+					Type: block.OutGoingOpDeposit,
+					Data: bridgeOp1,
 				},
 				{
-					MBType: block.OutGoingMbDeposit,
-					Data:   bridgeOp2,
+					Type: block.OutGoingOpDeposit,
+					Data: bridgeOp2,
 				},
 			}, nil
 		},
@@ -944,7 +944,7 @@ func TestSovereignShardProcessor_CreateBlock(t *testing.T) {
 		bridgeOp := sovArgs.OutGoingOperationsPool.Get(outGoingOpsHash)
 		require.NotNil(t, bridgeOp)
 		require.Equal(t, bridgeOp.OutGoingOperations, []*sovereignCore.OutGoingOperation{{
-			Type: int32(block.OutGoingMbChangeValidatorSet),
+			Type: int32(block.OutGoingOpChangeValidatorSet),
 			Hash: outGoingOpHash,
 			Data: outGoingOp,
 		}})

--- a/process/block/sovereignChainBlock_test.go
+++ b/process/block/sovereignChainBlock_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-core-go/data/block"
 	sovereignCore "github.com/multiversx/mx-chain-core-go/data/sovereign"
+	dtoSov "github.com/multiversx/mx-chain-core-go/data/sovereign/dto"
 	dtaPool "github.com/multiversx/mx-chain-go/dataRetriever/dataPool/sovereign"
 	"github.com/multiversx/mx-chain-go/process/block/sovereign/incomingHeader/dto"
 	"github.com/stretchr/testify/require"
@@ -413,6 +414,7 @@ func TestSovereignChainBlockProcessor_createAndSetOutGoingMiniBlockTxs(t *testin
 		},
 		OutGoingMiniBlockHeaders: []*block.OutGoingMiniBlockHeader{
 			{
+				ChainID:                dtoSov.MVX,
 				Hash:                   expectedOutGoingMbHash,
 				OutGoingOperationsHash: bridgeOpsHash,
 			},
@@ -926,6 +928,7 @@ func TestSovereignShardProcessor_CreateBlock(t *testing.T) {
 			IsStartOfEpoch: true,
 			OutGoingMiniBlockHeaders: []*block.OutGoingMiniBlockHeader{
 				{
+					ChainID:                dtoSov.MVX,
 					Hash:                   outGoingMBHash,
 					OutGoingOperationsHash: outGoingOpsHash,
 				},

--- a/process/headerCheck/sovereignExtraHeaderSignatureVerifier.go
+++ b/process/headerCheck/sovereignExtraHeaderSignatureVerifier.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/multiversx/mx-chain-core-go/core/check"
 	"github.com/multiversx/mx-chain-core-go/data"
-	"github.com/multiversx/mx-chain-core-go/data/block"
 	crypto "github.com/multiversx/mx-chain-crypto-go"
 
 	"github.com/multiversx/mx-chain-go/common"
@@ -80,12 +79,11 @@ func (hsv *sovereignHeaderSigVerifier) getAggregatedSignature(
 		return nil, process.ErrNilHeaderProof
 	}
 
-	// Marius C: THIS IS actually chain ID
-	mbTypeStr := dd block.OutGoingOpType(outGoingMBHdr.GetChainID()).String()
-	extraSigHandler, found := proof.GetExtraSignatureHandlers()[mbTypeStr]
+	chainIDStr := outGoingMBHdr.GetChainID().String()
+	extraSigHandler, found := proof.GetExtraSignatureHandlers()[chainIDStr]
 	if !found {
-		return nil, fmt.Errorf("%w in sovereignHeaderSigVerifier.VerifyAggregatedSignature for header hash: %x, round: %d",
-			errNoExtraSignatureDataFoundInProof, proof.GetHeaderHash(), proof.GetHeaderRound())
+		return nil, fmt.Errorf("%w in sovereignHeaderSigVerifier.VerifyAggregatedSignature for header hash: %x, round: %d, chain: %s",
+			errNoExtraSignatureDataFoundInProof, proof.GetHeaderHash(), proof.GetHeaderRound(), chainIDStr)
 	}
 
 	return extraSigHandler.GetAggregatedSignature(), nil

--- a/process/headerCheck/sovereignExtraHeaderSignatureVerifier.go
+++ b/process/headerCheck/sovereignExtraHeaderSignatureVerifier.go
@@ -80,7 +80,8 @@ func (hsv *sovereignHeaderSigVerifier) getAggregatedSignature(
 		return nil, process.ErrNilHeaderProof
 	}
 
-	mbTypeStr := block.OutGoingMBType(outGoingMBHdr.GetChainID()).String()
+	// Marius C: THIS IS actually chain ID
+	mbTypeStr := dd block.OutGoingOpType(outGoingMBHdr.GetChainID()).String()
 	extraSigHandler, found := proof.GetExtraSignatureHandlers()[mbTypeStr]
 	if !found {
 		return nil, fmt.Errorf("%w in sovereignHeaderSigVerifier.VerifyAggregatedSignature for header hash: %x, round: %d",

--- a/process/headerCheck/sovereignExtraHeaderSignatureVerifier_test.go
+++ b/process/headerCheck/sovereignExtraHeaderSignatureVerifier_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/core/check"
 	"github.com/multiversx/mx-chain-core-go/data/block"
+	"github.com/multiversx/mx-chain-core-go/data/sovereign/dto"
 	crypto "github.com/multiversx/mx-chain-crypto-go"
 	"github.com/stretchr/testify/require"
 
@@ -120,7 +121,7 @@ func TestSovereignHeaderSigVerifier_getAggregatedSignature(t *testing.T) {
 	t.Run("andromeda active, extra sig data not found for specific outgoing mb header", func(t *testing.T) {
 		proof := &block.HeaderProof{
 			ExtraSignatures: map[string]*block.ExtraSignatureData{
-				block.OutGoingMbChangeValidatorSet.String(): {
+				dto.MVX.String(): {
 					AggregatedSignature: outGoingAggregatedSig,
 				},
 			},
@@ -134,7 +135,7 @@ func TestSovereignHeaderSigVerifier_getAggregatedSignature(t *testing.T) {
 		aggregatedSigFromProof := []byte("aggregatedSigFromProof")
 		proof := &block.HeaderProof{
 			ExtraSignatures: map[string]*block.ExtraSignatureData{
-				block.OutGoingMbDeposit.String(): {
+				dto.MVX.String(): {
 					AggregatedSignature: aggregatedSigFromProof,
 				},
 			},

--- a/process/headerCheck/sovereignExtraHeaderSignatureVerifier_test.go
+++ b/process/headerCheck/sovereignExtraHeaderSignatureVerifier_test.go
@@ -100,6 +100,7 @@ func TestSovereignHeaderSigVerifier_getAggregatedSignature(t *testing.T) {
 	outGoingOpHash := []byte("outGoingOpHash")
 	outGoingAggregatedSig := []byte("aggregatedSig")
 	outGoingMBHeader := &block.OutGoingMiniBlockHeader{
+		ChainID:                               dto.MVX,
 		OutGoingOperationsHash:                outGoingOpHash,
 		AggregatedSignatureOutGoingOperations: outGoingAggregatedSig,
 	}
@@ -118,7 +119,7 @@ func TestSovereignHeaderSigVerifier_getAggregatedSignature(t *testing.T) {
 		require.Equal(t, process.ErrNilHeaderProof, err)
 	})
 
-	t.Run("andromeda active, extra sig data not found for specific outgoing mb header", func(t *testing.T) {
+	t.Run("andromeda active, extra sig data not found for specific chain ID in outgoing mb header", func(t *testing.T) {
 		proof := &block.HeaderProof{
 			ExtraSignatures: map[string]*block.ExtraSignatureData{
 				dto.MVX.String(): {
@@ -126,7 +127,9 @@ func TestSovereignHeaderSigVerifier_getAggregatedSignature(t *testing.T) {
 				},
 			},
 		}
-		aggSig, err := sovVerifier.getAggregatedSignature(outGoingMBHeader, proof, 0)
+		outGoingMBHeaderCopy := *outGoingMBHeader
+		outGoingMBHeaderCopy.ChainID = dto.UNSPECIFIED
+		aggSig, err := sovVerifier.getAggregatedSignature(&outGoingMBHeaderCopy, proof, 0)
 		require.Nil(t, aggSig)
 		require.ErrorIs(t, err, errNoExtraSignatureDataFoundInProof)
 	})


### PR DESCRIPTION
## Reasoning behind the pull request
- Outgoing op type and chain id
  
## Proposed changes
- Integrated changes from https://github.com/multiversx/mx-chain-core-sovereign-go/pull/29
- Removed outgoing mb header type and replaced it with chain id 
- Extra header data **proofs** will be per chain,  per mb type
- Extra **signers** will sign data per chain, not mb type
- 

## Testing procedure
- 
- 
- 

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
