### PR TITLE
update native esdt for sovereign chain simulator

### DIFF
--- a/cmd/sovereignnode/chainSimulator/sovereignChainSimulator.go
+++ b/cmd/sovereignnode/chainSimulator/sovereignChainSimulator.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	numOfShards = 1
-	nativeESDT  = "WEGLD-a1b2c3"
+	baseTokenID = "EGLD-000000"
 )
 
 // ArgsSovereignChainSimulator holds the arguments for sovereign chain simulator
@@ -53,7 +53,6 @@ func NewSovereignChainSimulator(args ArgsSovereignChainSimulator) (chainSimulato
 		cfg.SystemSCConfig.ESDTSystemSCConfig.ESDTPrefix = "sov"
 		cfg.GeneralConfig.Versions.VersionsByEpochs = []config.VersionByEpochs{{StartEpoch: 0, Version: string(process.SovereignHeaderVersion)}}
 		cfg.SystemSCConfig.StakingSystemSCConfig.NodeLimitPercentage = 0.4
-		cfg.GeneralConfig.GeneralSettings.BaseTokenID = nativeESDT
 
 		if alterConfigs != nil {
 			alterConfigs(cfg)
@@ -72,7 +71,7 @@ func NewSovereignChainSimulator(args ArgsSovereignChainSimulator) (chainSimulato
 			return sovCommon.CreateSovereignRunTypeComponents(args, *configs.SovereignExtraConfig)
 		}
 	}
-	args.NodeFactory = node.NewSovereignNodeFactory(nativeESDT)
+	args.NodeFactory = node.NewSovereignNodeFactory(baseTokenID)
 	args.ChainProcessorFactory = NewSovereignChainHandlerFactory()
 	args.GenerateGenesisFile = func(args chainSimulatorConfigs.ArgsChainSimulatorConfigs, configs *config.Configs) (*dtos.InitialWalletKeys, error) {
 		return sovChainSimConfig.GenerateSovereignGenesisFile(args, configs)

--- a/cmd/sovereignnode/chainSimulator/sovereignChainSimulator.go
+++ b/cmd/sovereignnode/chainSimulator/sovereignChainSimulator.go
@@ -45,6 +45,7 @@ func NewSovereignChainSimulator(args ArgsSovereignChainSimulator) (chainSimulato
 		return nil, err
 	}
 
+	var nativeBaseToken string
 	args.AlterConfigsFunction = func(cfg *config.Configs) {
 		cfg.EpochConfig = configs.EpochConfig
 		cfg.GeneralConfig.SovereignConfig = *configs.SovereignExtraConfig
@@ -53,11 +54,12 @@ func NewSovereignChainSimulator(args ArgsSovereignChainSimulator) (chainSimulato
 		cfg.SystemSCConfig.ESDTSystemSCConfig.ESDTPrefix = "sov"
 		cfg.GeneralConfig.Versions.VersionsByEpochs = []config.VersionByEpochs{{StartEpoch: 0, Version: string(process.SovereignHeaderVersion)}}
 		cfg.SystemSCConfig.StakingSystemSCConfig.NodeLimitPercentage = 0.4
-
 		if alterConfigs != nil {
 			alterConfigs(cfg)
 			configs.SovereignExtraConfig = &cfg.GeneralConfig.SovereignConfig
 		}
+
+		nativeBaseToken = cfg.GeneralConfig.GeneralSettings.BaseTokenID
 	}
 
 	args.CreateRunTypeCoreComponents = func() (factory.RunTypeCoreComponentsHolder, error) {
@@ -71,7 +73,8 @@ func NewSovereignChainSimulator(args ArgsSovereignChainSimulator) (chainSimulato
 			return sovCommon.CreateSovereignRunTypeComponents(args, *configs.SovereignExtraConfig)
 		}
 	}
-	args.NodeFactory = node.NewSovereignNodeFactory(baseTokenID)
+
+	args.NodeFactory = node.NewSovereignNodeFactory(nativeBaseToken)
 	args.ChainProcessorFactory = NewSovereignChainHandlerFactory()
 	args.GenerateGenesisFile = func(args chainSimulatorConfigs.ArgsChainSimulatorConfigs, configs *config.Configs) (*dtos.InitialWalletKeys, error) {
 		return sovChainSimConfig.GenerateSovereignGenesisFile(args, configs)

--- a/cmd/sovereignnode/chainSimulator/sovereignChainSimulator.go
+++ b/cmd/sovereignnode/chainSimulator/sovereignChainSimulator.go
@@ -45,7 +45,7 @@ func NewSovereignChainSimulator(args ArgsSovereignChainSimulator) (chainSimulato
 		return nil, err
 	}
 
-	var nativeBaseToken string
+	var nativeBaseToken = baseTokenID
 	args.AlterConfigsFunction = func(cfg *config.Configs) {
 		cfg.EpochConfig = configs.EpochConfig
 		cfg.GeneralConfig.SovereignConfig = *configs.SovereignExtraConfig

--- a/cmd/sovereignnode/chainSimulator/tests/bridge/bridge_test.go
+++ b/cmd/sovereignnode/chainSimulator/tests/bridge/bridge_test.go
@@ -249,6 +249,7 @@ func TestSovereignChainSimulator_DeployBridgeContractsAndDepositMainChainToken(t
 				}
 				cfg.GeneralConfig.SovereignConfig.OutgoingSubscribedEvents.TimeToWaitForUnconfirmedOutGoingOperationInSeconds = 1
 				cfg.GeneralConfig.VirtualMachine.Execution.TransferAndExecuteByUserAddresses = []string{outGoingSubscribedAddress}
+				cfg.GeneralConfig.GeneralSettings.BaseTokenID = "WEGLD-1a2b3c"
 			},
 		},
 	})

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/multiversx/mx-chain-go
 
 replace (
 	github.com/multiversx/mx-chain-core-go => github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20250909112243-f8ad1a2c5594
-	github.com/multiversx/mx-chain-es-indexer-go => github.com/multiversx/mx-chain-es-indexer-sovereign-go v1.7.17-0.20250910114812-bd0aeddd143d
+	github.com/multiversx/mx-chain-es-indexer-go => github.com/multiversx/mx-chain-es-indexer-sovereign-go v1.7.17-0.20251208083904-141b61a79af7
 	github.com/multiversx/mx-chain-vm-common-go => github.com/multiversx/mx-chain-vm-common-sovereign-go v1.5.17-0.20250915142157-e75c211f22ea
 )
 

--- a/go.sum
+++ b/go.sum
@@ -409,8 +409,8 @@ github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20250909112243-f8ad1a
 github.com/multiversx/mx-chain-core-sovereign-go v1.2.25-0.20250909112243-f8ad1a2c5594/go.mod h1:cJw3+5HfcHb5uIf3f/0cjYBXq6jumM3TNeQAY8UQFF0=
 github.com/multiversx/mx-chain-crypto-go v1.3.0 h1:0eK2bkDOMi8VbSPrB1/vGJSYT81IBtfL4zw+C4sWe/k=
 github.com/multiversx/mx-chain-crypto-go v1.3.0/go.mod h1:nPIkxxzyTP8IquWKds+22Q2OJ9W7LtusC7cAosz7ojM=
-github.com/multiversx/mx-chain-es-indexer-sovereign-go v1.7.17-0.20250910114812-bd0aeddd143d h1:jFA1uclN3wuqpBQwj/XoU7B30p4DH5gRrQQkIA92p68=
-github.com/multiversx/mx-chain-es-indexer-sovereign-go v1.7.17-0.20250910114812-bd0aeddd143d/go.mod h1:tPwxRZQccxnGlZLNJWBbtD8ABc8XlSpDpeeEMK+hM68=
+github.com/multiversx/mx-chain-es-indexer-sovereign-go v1.7.17-0.20251208083904-141b61a79af7 h1:I8L3OL5wIGm3z1r14WRvuYXBKhdEqnU/aaxHp26dCPo=
+github.com/multiversx/mx-chain-es-indexer-sovereign-go v1.7.17-0.20251208083904-141b61a79af7/go.mod h1:ZxIAVkd/BOQY4Gg/Yt+hi1dyEZnZRWHemEe/im1YwNc=
 github.com/multiversx/mx-chain-logger-go v1.1.0 h1:97x84A6L4RfCa6YOx1HpAFxZp1cf/WI0Qh112whgZNM=
 github.com/multiversx/mx-chain-logger-go v1.1.0/go.mod h1:K9XgiohLwOsNACETMNL0LItJMREuEvTH6NsoXWXWg7g=
 github.com/multiversx/mx-chain-scenario-go v1.6.0 h1:cwDFuS1pSc4YXnfiKKDTEb+QDY4fulPQaiRgIebnKxI=


### PR DESCRIPTION
## Reasoning behind the pull request
- `multiESDTNFTTransfer` tests are failing because `Get Balance` is looking for `EGLD-000000`
- 
- 
  
## Proposed changes
- Set `EGLD-000000` as base token id for sovereign chain simulator
- Change the base token id for specific tests where we need custom base token id (e.g. Cross-chain EGLD transfers)
- Extra: Update es-indexer go.mod

## Testing procedure
- 
- 
- 

## Pre-requisites

Based on the [Contributing Guidelines](https://github.com/multiversx/mx-chain-go/blob/master/.github/CONTRIBUTING.md#branches-management) the PR author and the reviewers must check the following requirements are met:
- was the PR targeted to the correct branch?
- if this is a larger feature that probably needs more than one PR, is there a `feat` branch created?
- if this is a `feat` branch merging, do all satellite projects have a proper tag inside `go.mod`?
